### PR TITLE
Extend FlashAttention Prefill with KV cache

### DIFF
--- a/applications/flash_attention_v2/collective/xe_flash_attn_epilogue.hpp
+++ b/applications/flash_attention_v2/collective/xe_flash_attn_epilogue.hpp
@@ -116,7 +116,7 @@ public:
   template <class ProblemShape>
   static constexpr Params to_underlying_arguments(ProblemShape const &problem_shape, Arguments const &args,
                                                   [[maybe_unused]] void *workspace) {
-    auto [batch, num_heads, seq_len_qo, seq_len_kv, head_size_qk, head_size_vo] = problem_shape;
+    auto [batch, num_heads, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo] = problem_shape;
 
     auto tensorO = make_tensor(make_gmem_ptr(static_cast<ElementO const*>(args.ptr_O)), 
                                                   make_layout(make_shape(seq_len_qo, head_size_vo, batch * num_heads), 
@@ -179,7 +179,7 @@ public:
     }
 
     // Indexing variables
-    auto [batch, num_heads, seq_len_qo, seq_len_kv, head_size_qk, head_size_vo] = problem_shape;
+    auto [batch, num_heads, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo] = problem_shape;
     // Represent the full output tensor
     Tensor mO_mnl = cute::get_pvc_tensor(make_shape(seq_len_qo, head_size_vo, (is_var_len ? batch : 1) * num_heads));
     
@@ -204,7 +204,7 @@ public:
     if constexpr (!VarLen) {
       return params;
     } else {
-      auto [batch, num_heads, seq_len_qo, seq_len_kv, head_size_qk, head_size_vo] = problem_shape;
+      auto [batch, num_heads, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo] = problem_shape;
 
       auto qo_cumulative_length = get<2>(problem_shape).cumulative_length;
       int offset_o = num_heads * head_size_vo * qo_cumulative_length[l_coord];

--- a/applications/flash_attention_v2/collective/xe_flash_attn_mma.hpp
+++ b/applications/flash_attention_v2/collective/xe_flash_attn_mma.hpp
@@ -204,7 +204,7 @@ struct CollectiveMmaAttention<gemm::MainloopIntelPVC<Stages>, ProblemShapeType_,
     XE_Copy_K copyK_cache{XE_Copy_K{}.with(tensorK_cache)};
     XE_Copy_V copyV_cache{XE_Copy_V{}.with(tensorV_cache)};
 
-    return Params{copyQ, copyK, copyV,  copyK_cache, copyV_cache, tensorK_cache, tensorV_cache};
+    return Params{copyQ, copyK, copyV, copyK_cache, copyV_cache, tensorK_cache, tensorV_cache};
   }
 
   template <class FragQccum, class TensorQ, class TensorK, class FragSrc>

--- a/applications/flash_attention_v2/collective/xe_flash_attn_mma.hpp
+++ b/applications/flash_attention_v2/collective/xe_flash_attn_mma.hpp
@@ -176,8 +176,6 @@ struct CollectiveMmaAttention<gemm::MainloopIntelPVC<Stages>, ProblemShapeType_,
     XE_Copy_V gmem_tiled_copy_v;
     XE_Copy_K gmem_tiled_copy_k_cache;
     XE_Copy_V gmem_tiled_copy_v_cache;
-    TensorK gmem_tensor_k_cache;
-    TensorV gmem_tensor_v_cache;
   };
 
   //
@@ -204,7 +202,7 @@ struct CollectiveMmaAttention<gemm::MainloopIntelPVC<Stages>, ProblemShapeType_,
     XE_Copy_K copyK_cache{XE_Copy_K{}.with(tensorK_cache)};
     XE_Copy_V copyV_cache{XE_Copy_V{}.with(tensorV_cache)};
 
-    return Params{copyQ, copyK, copyV, copyK_cache, copyV_cache, tensorK_cache, tensorV_cache};
+    return Params{copyQ, copyK, copyV, copyK_cache, copyV_cache};
   }
 
   template <class FragQccum, class TensorQ, class TensorK, class FragSrc>
@@ -379,7 +377,7 @@ struct CollectiveMmaAttention<gemm::MainloopIntelPVC<Stages>, ProblemShapeType_,
       XE_Copy_K copyK_cache{XE_Copy_K{}.with(tensorK_cache)};
       XE_Copy_V copyV_cache{XE_Copy_V{}.with(tensorV_cache)};
 
-      return Params{copyQ, copyK, copyV, copyK_cache, copyV_cache, tensorK_cache, tensorV_cache};
+      return Params{copyQ, copyK, copyV, copyK_cache, copyV_cache};
     }
   }
 };

--- a/applications/flash_attention_v2/collective/xe_flash_attn_mma.hpp
+++ b/applications/flash_attention_v2/collective/xe_flash_attn_mma.hpp
@@ -181,7 +181,7 @@ struct CollectiveMmaAttention<gemm::MainloopIntelPVC<Stages>, ProblemShapeType_,
                                                   void *workspace) {
     (void)workspace;
 
-    auto [batch, num_heads, seq_len_qo, seq_len_kv, head_size_qk, head_size_vo] = problem_shape;
+    auto [batch, num_heads, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo] = problem_shape;
 
     auto tensorQ = make_tensor(make_gmem_ptr(args.ptr_Q), make_layout(make_shape(seq_len_qo, head_size_qk, batch * num_heads), args.dQ));
     auto tensorK = make_tensor(make_gmem_ptr(args.ptr_K), make_layout(make_shape(seq_len_kv, head_size_qk, batch * num_heads), args.dK));
@@ -308,7 +308,7 @@ struct CollectiveMmaAttention<gemm::MainloopIntelPVC<Stages>, ProblemShapeType_,
     if constexpr (!is_var_len) {
       return params;
     } else {
-      auto [batch, num_heads, seq_len_qo, seq_len_kv, head_size_qk, head_size_vo] = problem_shape;
+      auto [batch, num_heads, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo] = problem_shape;
 
       auto qo_cumulative_length = get<2>(problem_shape).cumulative_length;
       auto kv_cumulative_length = get<3>(problem_shape).cumulative_length;

--- a/applications/flash_attention_v2/kernel/tile_scheduler.hpp
+++ b/applications/flash_attention_v2/kernel/tile_scheduler.hpp
@@ -59,8 +59,8 @@ struct XeFlashIndividualTileScheduler {
       ProblemSize const& problem_size, KernelHardwareInfo hw_info,
       TileShape const& tile_shape) {
     using namespace cute;
-    // problem_size = [batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, head_size_qk, head_size_vo]
-    dim3 grid(size(ceil_div(shape<6>(problem_size), shape<1>(tile_shape))),
+    // problem_size = [batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache head_size_qk, head_size_vo]
+    dim3 grid(size(ceil_div(shape<7>(problem_size), shape<1>(tile_shape))),
               size(ceil_div(shape<3>(problem_size), shape<0>(tile_shape))),
               size(shape<0>(problem_size) * shape<1>(problem_size)));
     return Params{ grid, {shape<1>(problem_size)} };
@@ -127,8 +127,8 @@ struct XeFlashPersistentTileScheduler {
     CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << sm_count);
     hw_info.sm_count = sm_count;
 
-    // problem_size = [batch, num_heads_q, numhead_kv, seq_len_qo, seq_len_kv, head_size_qk, head_size_vo]
-    int num_head_size_blocks = size(ceil_div(shape<6>(problem_size), shape<1>(tile_shape)));
+    // problem_size = [batch, num_heads_q, numhead_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo]
+    int num_head_size_blocks = size(ceil_div(shape<7>(problem_size), shape<1>(tile_shape)));
     int num_seq_len_blocks = size(ceil_div(shape<3>(problem_size), shape<0>(tile_shape)));
     int num_blocks = num_seq_len_blocks * num_head_size_blocks * size(shape<0>(problem_size) * shape<1>(problem_size));
 

--- a/applications/flash_attention_v2/kernel/tile_scheduler.hpp
+++ b/applications/flash_attention_v2/kernel/tile_scheduler.hpp
@@ -59,7 +59,7 @@ struct XeFlashIndividualTileScheduler {
       ProblemSize const& problem_size, KernelHardwareInfo hw_info,
       TileShape const& tile_shape) {
     using namespace cute;
-    // problem_size = [batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache head_size_qk, head_size_vo]
+    // problem_size = [batch, num_heads_q, num_heads_kv, seq_len_qo, seq_len_kv, seq_len_kv_cache, head_size_qk, head_size_vo]
     dim3 grid(size(ceil_div(shape<7>(problem_size), shape<1>(tile_shape))),
               size(ceil_div(shape<3>(problem_size), shape<0>(tile_shape))),
               size(shape<0>(problem_size) * shape<1>(problem_size)));

--- a/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
@@ -349,7 +349,7 @@ public:
 
         // we only need one block ahead, there is enough gap to prefetch it while doing softmax. because the gap between the two MMA is big,
         // prefetching it the same way as cutlass K matrix does not make sense
-        (is_KV_cache) ? prefetch(tiled_prefetch_v.with(mainloop_params.gmem_tensor_v_cache), pVgV_cache(_, _, _ , nblock))
+        is_KV_cache ? prefetch(tiled_prefetch_v.with(mainloop_params.gmem_tensor_v_cache), pVgV_cache(_, _, _ , nblock))
                       : prefetch(tiled_prefetch_v, pVgV(_, _, _ , nblock - nblock_cache));
 
         // 4) Fused softmax

--- a/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
@@ -334,7 +334,7 @@ public:
       for (int nblock = 0; nblock < nblock_limit - static_cast<int>(CausalMask); nblock++) {
         barrier_arrive(barrier_scope);
 
-        bool is_KV_cache = (nblock < nblock_cache);
+        bool is_KV_cache = nblock < nblock_cache;
 
         // 1) Load KV (performed inside mmaQK)
         auto gK_ = is_KV_cache ? gK_cache(_, _, nblock, _) : gK(_, _, nblock - nblock_cache, _);

--- a/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
@@ -390,7 +390,7 @@ public:
             int row_idx = m * Vec + seq_coord;
             CUTLASS_PRAGMA_UNROLL
             for (int row = 0; row < Vec; row++, row_idx++) { // 8
-              if ((col_idx - full_tile_offset) > (row_idx - discard_seq_coord)) {
+              if (col_idx - full_tile_offset > row_idx - discard_seq_coord) {
                 tSr(row, m, n) = -INFINITY;
               }
             }

--- a/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
@@ -324,11 +324,10 @@ public:
         barrier_arrive(barrier_scope);
 
         bool is_KV_cache = (nblock < nblock_cache);
-        int local_block = is_KV_cache ? nblock : (nblock - nblock_cache);
-
+   
         // 1) Load KV (performed inside mmaQK)
-        auto gK_ = is_KV_cache ? gK_cache(_, _, local_block, _) : gK(_, _, local_block, _);
-        auto gV_ = is_KV_cache ? gV_cache(_, _, local_block) : gV(_, _, local_block);
+        auto gK_ = is_KV_cache ? gK_cache(_, _, nblock, _) : gK(_, _, nblock - nblock_cache, _);
+        auto gV_ = is_KV_cache ? gV_cache(_, _, nblock) : gV(_, _, nblock - nblock_cache);
 
         // 2) Create Tensor S
         Tensor tSr = make_tensor<ElementAccumulator>(Shape<Int<Vec>, Int<FragsM>, Int<FragsN>>{});

--- a/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
@@ -277,6 +277,7 @@ public:
       const int nblock_new = CausalMask ? cute::ceil_div(causal_seq_len, QK_BLK_N)
                                           : cute::ceil_div(non_causal_seq_len, QK_BLK_N);
       int nblock_limit = nblock_cache + nblock_new;
+      bool is_first_block = (seq_len_kv_cache == 0) && ((nblock_new - 1) == 0);
 
       auto mainloop_params = CollectiveMainloop::get_updated_copies(params.mainloop, params.problem_shape, batch_coord);
 
@@ -386,7 +387,7 @@ public:
         }
 
         CollectiveSoftmaxEpilogue softmax(params.softmax);
-        softmax((nblock_new - 1) == 0, tSr, max_reg, sum_reg, out_reg);
+        softmax(is_first_block, tSr, max_reg, sum_reg, out_reg);
 
         collective_mma.mmaPV(out_reg, tSr,  gV(_, _ , nblock_new - 1), out_reg, mainloop_params, false);
       }

--- a/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
@@ -386,7 +386,7 @@ public:
         }
 
         CollectiveSoftmaxEpilogue softmax(params.softmax);
-        softmax(is_first_block, tSr, max_reg, sum_reg, out_reg);
+        softmax((nblock_limit - 1) == 0, tSr, max_reg, sum_reg, out_reg);
 
         collective_mma.mmaPV(out_reg, tSr,  gV(_, _ , nblock_new - 1), out_reg, mainloop_params, false);
       }

--- a/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
@@ -277,7 +277,6 @@ public:
       const int nblock_new = CausalMask ? cute::ceil_div(causal_seq_len, QK_BLK_N)
                                           : cute::ceil_div(non_causal_seq_len, QK_BLK_N);
       int nblock_limit = nblock_cache + nblock_new;
-      bool is_first_block = (seq_len_kv_cache == 0) && ((nblock_new - 1) == 0);
 
       auto mainloop_params = CollectiveMainloop::get_updated_copies(params.mainloop, params.problem_shape, batch_coord);
 

--- a/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_gemm.hpp
@@ -368,7 +368,7 @@ public:
         auto& prefetch_k_selector = sel_prefetch_k ? tiled_prefetch_k_cache: tiled_prefetch_k;
         auto& pKgK_ = sel_prefetch_k  ? pKgK_cache : pKgK;
         CUTLASS_PRAGMA_UNROLL
-        for (int j = 0; j < size<4>(pKgK); j++) {
+        for (int j = 0; j < size<4>(pKgK_); j++) {
               prefetch(prefetch_k_selector, pKgK_(_, _, _, (nblock + DispatchPolicy::Stages) - (!sel_prefetch_k) * nblock_cache , j));         
         }
         barrier_wait(barrier_scope);

--- a/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
+++ b/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
@@ -213,7 +213,7 @@ template <class GemmKernel, bool isVarLen> struct ExampleRunner {
         seq_len_kv = get<4>(problem_size);
         seq_len_kv_cache = get<5>(problem_size);
       }
-      int seq_len_kv_total = use_kv_cache ? (seq_len_kv_cache + seq_len_kv) : seq_len_kv;
+      int seq_len_kv_total = seq_len_kv_cache + seq_len_kv;
       int kv_group_update=1;
 
       for (int h = 0; h < num_heads_q; h++) {
@@ -391,7 +391,7 @@ template <class GemmKernel, bool isVarLen> struct ExampleRunner {
   template<class ProblemShape>
   auto initialize_varlen(const ProblemShape& problem_size, const bool VarlenSame = true) {
     int num_batches = get<0>(problem_size);
-    int seq_len_kv_cache = get<4>(problem_size);
+    int seq_len_kv_cache = get<5>(problem_size);
 
     // generate Q as --b times
     //    gaussian (--Q, --Q / 2) sampled positive

--- a/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
+++ b/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
@@ -371,10 +371,10 @@ template <class GemmKernel, bool isVarLen> struct ExampleRunner {
         if(kv_group_update % q_group_size==0) {
           offset_k += seq_len_kv * head_size_qk;
           offset_v += seq_len_kv * head_size_vo;
+          offset_k_cache += seq_len_kv_cache * head_size_qk;
+          offset_v_cache += seq_len_kv_cache * head_size_vo;
         }
         kv_group_update++;
-        offset_k_cache += seq_len_kv_cache * head_size_qk;
-        offset_v_cache += seq_len_kv_cache * head_size_vo;
         offset_o += seq_len_qo * head_size_vo;
       }
     }

--- a/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
+++ b/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
@@ -442,7 +442,7 @@ template <class GemmKernel, bool isVarLen> struct ExampleRunner {
     get<4>(problem_size_for_launch) = cutlass::fmha::collective::VariableLength{max_seqlen_kv};
     get<5>(problem_size_for_launch) = get<5>(problem_size);
     get<6>(problem_size_for_launch) = get<6>(problem_size);
-    get<7>(problem_size_for_launch) = get<6>(problem_size);
+    get<7>(problem_size_for_launch) = get<7>(problem_size);
     get<0>(problem_size_for_launch) = get<0>(problem_size);
     get<1>(problem_size_for_launch) = get<1>(problem_size);
     get<2>(problem_size_for_launch) = get<2>(problem_size);

--- a/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
+++ b/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
@@ -602,11 +602,11 @@ template <class GemmKernel, bool isVarLen> struct ExampleRunner {
       syclcompat::wait();
 
       double cute_time = timer.seconds() / options.iterations;
-      double flops_qk = 2.0 * options.batch * options.num_heads_q * options.seq_len_qo * options.seq_len_kv * options.head_size_qk;
-      double flops_pv = 2.0 * options.batch * options.num_heads_q * options.seq_len_qo * options.head_size_vo * options.seq_len_kv;
+      double flops_qk = 2.0 * options.batch * options.num_heads_q * options.seq_len_qo * (options.seq_len_kv + options.seq_len_kv_cache) * options.head_size_qk;
+      double flops_pv = 2.0 * options.batch * options.num_heads_q * options.seq_len_qo * options.head_size_vo * (options.seq_len_kv + options.seq_len_kv_cache);
       double tflops = ((flops_qk + flops_pv) * 1e-12) / cute_time;
-      double gbps_qk = 2.0 * options.batch * options.num_heads_q * (options.seq_len_qo * options.head_size_qk + options.seq_len_kv * options.head_size_qk);
-      double gbps_pv = 2.0 * options.batch * options.num_heads_q * (options.seq_len_kv * options.seq_len_qo + options.seq_len_qo * options.head_size_vo);
+      double gbps_qk = 2.0 * options.batch * options.num_heads_q * (options.seq_len_qo * options.head_size_qk + (options.seq_len_kv + options.seq_len_kv_cache) * options.head_size_qk);
+      double gbps_pv = 2.0 * options.batch * options.num_heads_q * ((options.seq_len_kv + options.seq_len_kv_cache) * options.seq_len_qo + options.seq_len_qo * options.head_size_vo);
       double gbps = ((gbps_qk + gbps_pv)  * 1e-9) / (cute_time);
       std::cout << "Batch: " << options.batch << "\tNumHeads_q: " << options.num_heads_q << "\tNumHeads_kv: " << options.num_heads_kv << "\tSeq Length QO: " << options.seq_len_qo
           << "\tSeq Length KV: " << options.seq_len_kv << "\tSeq Length KV Cache: " << options.seq_len_kv_cache 


### PR DESCRIPTION
Moved to https://github.com/codeplaysoftware/cutlass-sycl/pull/331.

This extends FlashAttention prefill with cached KV in addition to current KV (blue box in the below figure). Both causal and non-causal are supported. 
<img width="611" alt="extend prefill" src="https://github.com/user-attachments/assets/d27e5dc6-5700-447e-b8c8-33e8073d7891" />
