### PR TITLE
Correct Tflops, bandwidth calculation with causal mask for FlashAttention

### DIFF
--- a/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
+++ b/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
@@ -531,12 +531,16 @@ template <class GemmKernel, bool isVarLen> struct ExampleRunner {
       }
       syclcompat::wait();
 
+      double effective_seq_len_kv = options.is_causal ?
+        (options.seq_len_kv + options.seq_len_kv_cache) / 2.0 :
+        (options.seq_len_kv + options.seq_len_kv_cache);
+      
       double cute_time = timer.seconds() / options.iterations;
-      double flops_qk = 2.0 * options.batch * options.num_heads_q * options.seq_len_qo * options.seq_len_kv * options.head_size_qk;
-      double flops_pv = 2.0 * options.batch * options.num_heads_q * options.seq_len_qo * options.head_size_vo * options.seq_len_kv;
+      double flops_qk = 2.0 * options.batch * options.num_heads_q * options.seq_len_qo * effective_seq_len_kv * options.head_size_qk;
+      double flops_pv = 2.0 * options.batch * options.num_heads_q * options.seq_len_qo * options.head_size_vo * effective_seq_len_kv;
       double tflops = ((flops_qk + flops_pv) * 1e-12) / cute_time;
-      double gbps_qk = 2.0 * options.batch * options.num_heads_q * (options.seq_len_qo * options.head_size_qk + options.seq_len_kv * options.head_size_qk);
-      double gbps_pv = 2.0 * options.batch * options.num_heads_q * (options.seq_len_kv * options.seq_len_qo + options.seq_len_qo * options.head_size_vo);
+      double gbps_qk = 2.0 * options.batch * options.num_heads_q * (options.seq_len_qo * options.head_size_qk + effective_seq_len_kv * options.head_size_qk);
+      double gbps_pv = 2.0 * options.batch * options.num_heads_q * (effective_seq_len_kv * options.seq_len_qo + options.seq_len_qo * options.head_size_vo);
       double gbps = ((gbps_qk + gbps_pv)  * 1e-9) / (cute_time);
       std::cout << "Batch: " << options.batch << "\tNumHeads_q: " << options.num_heads_q  << "\tNumHeads_kv: " << options.num_heads_kv  << "\tSeq Length QO: " << options.seq_len_qo
                 << "\tSeq Length KV: " << options.seq_len_kv << "\tHead Size QK: " << options.head_size_qk << "\tHead Size VO: " << options.head_size_vo

--- a/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
+++ b/examples/sycl/06_pvc_flash_attention/pvc_flash_attn_runner.hpp
@@ -532,8 +532,8 @@ template <class GemmKernel, bool isVarLen> struct ExampleRunner {
       syclcompat::wait();
 
       double effective_seq_len_kv = options.is_causal ?
-        (options.seq_len_kv + options.seq_len_kv_cache) / 2.0 :
-        (options.seq_len_kv + options.seq_len_kv_cache);
+        options.seq_len_kv / 2.0 :
+        options.seq_len_kv;
       
       double cute_time = timer.seconds() / options.iterations;
       double flops_qk = 2.0 * options.batch * options.num_heads_q * options.seq_len_qo * effective_seq_len_kv * options.head_size_qk;


### PR DESCRIPTION
With causal mask, `nblock_limit` is up to the diagonal boundary of the causal mask. The computation flops should be around half of without causal mask, as there is half of computation. The memory bandwidth should also be around half, as there is half of read/write. 

<img width="307" alt="with_causal" src="https://github.com/user-attachments/assets/a89cdbe2-2ddb-4fc3-9382-97e8b23e4e49" />
<img width="313" alt="without_causal" src="https://github.com/user-attachments/assets/861b82de-8d24-40ed-bded-a95a4504427b" />
