### PR TITLE
Fix failing unit tests on BMG

### DIFF
--- a/test/unit/gemm/device/gemm_testbed_3x.hpp
+++ b/test/unit/gemm/device/gemm_testbed_3x.hpp
@@ -4040,7 +4040,7 @@ bool TestXe(
   std::vector<int> problem_size_l = test_batch ? std::vector{1, 3, 4} : std::vector{1};
 
   constexpr int TileShapeK = cute::size<2>(typename Gemm::GemmKernel::TileShape{});
-  std::vector<int> problem_size_k{TileShapeK};
+  std::vector<int> problem_size_k{TileShapeK, TileShapeK*32};
 
   using DecompositionMode = typename cutlass::gemm::kernel::detail::PersistentTileSchedulerXeStreamKParams::DecompositionMode;
   std::vector decomposition_modes = {DecompositionMode::Heuristic};

--- a/test/unit/gemm/device/gemm_testbed_3x.hpp
+++ b/test/unit/gemm/device/gemm_testbed_3x.hpp
@@ -4018,7 +4018,7 @@ template <typename Gemm, template <class T> class ActivationFunctor =
 // TODO(Codeplay): remove the test_batch option once batching is enabled for all tests
 bool TestXe(
     double alpha = 1.0, double beta = 0.0,
-    bool test_batch = true, int max_alignment = 4,
+    bool test_batch = true, int max_alignment = 8,
     CheckEquality check_relative_equality = CheckEquality::RELATIVE) {
   using ElementScalar = typename Gemm::EpilogueOutputOp::ElementScalar;
   using ProblemShapeType = typename Gemm::GemmKernel::ProblemShape;

--- a/test/unit/gemm/device/gemm_universal_f16t_s4n_f32t_mixed_input_tensor_op_f32_xe.cpp
+++ b/test/unit/gemm/device/gemm_universal_f16t_s4n_f32t_mixed_input_tensor_op_f32_xe.cpp
@@ -131,7 +131,7 @@ TEST(XE_Device_GemmUniversal_f16t_s4n_f32t_mixed_input_tensor_op_f32, 128x128x64
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
   // TODO(Codeplay): gemm batch doesn't work for mixed type
-  bool passed = test::gemm::device::TestXe<Gemm>(1.0, 1.0, false, 8);
+  bool passed = test::gemm::device::TestXe<Gemm>(1.0, 1.0, false, 16);
   EXPECT_TRUE(passed);
 }
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/unit/gemm/device/gemm_universal_f16t_s4t_f32t_mixed_input_tensor_op_f32_xe.cpp
+++ b/test/unit/gemm/device/gemm_universal_f16t_s4t_f32t_mixed_input_tensor_op_f32_xe.cpp
@@ -131,7 +131,7 @@ TEST(XE_Device_GemmUniversal_f16t_s4t_f32t_mixed_input_tensor_op_f32, 128x128x64
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
   // TODO(Codeplay): gemm batch doesn't work for mixed type
-  bool passed = test::gemm::device::TestXe<Gemm>(1.0, 1.0, false, 8);
+  bool passed = test::gemm::device::TestXe<Gemm>(1.0, 1.0, false, 32);
   EXPECT_TRUE(passed);
 }
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32.cpp
+++ b/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32.cpp
@@ -65,7 +65,7 @@ TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32, 256x256x32) {
   using LayoutA = layout::RowMajor;
   using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32<LayoutA, LayoutB>::Gemm;
-  EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
+  EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, true, 16));
 }
 
 /*  TODO(Codeplay): Transposed copy are not implemented


### PR DESCRIPTION
BMG has alignment restrictions which don't seem to exist on PVC. This PR:
 - Sets alignment-friendly shapes in various GEMM unit tests
 - Uses padding (i.e. pitched tensor) to fix some block copy unit tests