### PR TITLE
Fix the performance regression for flash attention for 2025.1 release compiler

### DIFF
--- a/applications/flash_attention_v2/collective/xe_flash_attn_mma.hpp
+++ b/applications/flash_attention_v2/collective/xe_flash_attn_mma.hpp
@@ -47,25 +47,11 @@ using namespace cute;
 
 template <typename To_type, typename Engine, typename Layout>
 CUTLASS_DEVICE auto convert_type(Tensor<Engine, Layout> const &tensor) {
-#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20250200)
-  Tensor tPr = make_tensor<To_type>(shape(tensor));
-  CUTLASS_PRAGMA_UNROLL
-  for (int p_idx = 0; p_idx < size(tPr); p_idx++) {
-  #ifdef __SYCL_DEVICE_ONLY__
-    // Temporary patch to avoid linking in the devicelib fallback unconditionally.
-    tPr(p_idx).storage = __spirv_ConvertFToBF16INTEL(tensor(p_idx));
-  #else
-    tPr(p_idx) = static_cast<To_type>(tensor(p_idx));
-  #endif
-  }
-  return tPr;
-#else
   using From_type = typename Engine::value_type;
   constexpr int numel = decltype(size(tensor))::value;
   cutlass::NumericArrayConverter<To_type, From_type, numel> convert_op;
   auto frag = convert_op(*reinterpret_cast<const cutlass::Array<From_type, numel> *>(tensor.data()));
   return make_tensor(make_rmem_ptr<To_type>(&frag), tensor.layout());
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/cutlass/numeric_conversion.h
+++ b/include/cutlass/numeric_conversion.h
@@ -539,7 +539,15 @@ struct NumericConverter<cutlass::bfloat16_t, float, FloatRoundStyle::round_to_ne
 
   CUTLASS_HOST_DEVICE
   static result_type convert(source_type const & s) {
+    #ifdef __SYCL_DEVICE_ONLY__
+    // Temporary patch to avoid linking in the devicelib fallback unconditionally.
+    // Thisis the work around to fix performance regression in 2025.1 
+    result_type res;
+    res.storage=(__spirv_ConvertFToBF16INTEL(s));
+    return res;
+    #else
     return static_cast<cutlass::bfloat16_t>(s);
+    #endif
   }
 
   CUTLASS_HOST_DEVICE

--- a/include/cutlass/numeric_conversion.h
+++ b/include/cutlass/numeric_conversion.h
@@ -539,7 +539,7 @@ struct NumericConverter<cutlass::bfloat16_t, float, FloatRoundStyle::round_to_ne
 
   CUTLASS_HOST_DEVICE
   static result_type convert(source_type const & s) {
-    #ifdef __SYCL_DEVICE_ONLY__
+    #if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20250200) && defined(__SYCL_DEVICE_ONLY__)
     // Temporary patch to avoid linking in the devicelib fallback unconditionally.
     // This is the work around to fix performance regression in 2025.1 
     result_type res;

--- a/include/cutlass/numeric_conversion.h
+++ b/include/cutlass/numeric_conversion.h
@@ -541,7 +541,7 @@ struct NumericConverter<cutlass::bfloat16_t, float, FloatRoundStyle::round_to_ne
   static result_type convert(source_type const & s) {
     #ifdef __SYCL_DEVICE_ONLY__
     // Temporary patch to avoid linking in the devicelib fallback unconditionally.
-    // Thisis the work around to fix performance regression in 2025.1 
+    // This is the work around to fix performance regression in 2025.1 
     result_type res;
     res.storage=(__spirv_ConvertFToBF16INTEL(s));
     return res;


### PR DESCRIPTION
This PR is a workaround for  the performance regression in 2025.1 compiler. The following commit that fixes the issue(  https://github.com/intel/llvm/commit/71ca51fb52ccf0bd8f03d33cf9ea2962cf254a7f) did not meet the dpcpp 2025.1 cut-off date. This will be added in the 2025.2 release.