### PR TITLE
One of the differences between the intrinsic and the built-in functio…

### DIFF
--- a/include/cute/arch/xe_copy_1B.hpp
+++ b/include/cute/arch/xe_copy_1B.hpp
@@ -607,7 +607,7 @@ struct XE_2D_U8x1x64_LD_N {
                                       intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_8b_1r32x2c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch, coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
           "Trying to use block prefetch on non-PVC hardware");
@@ -639,7 +639,7 @@ struct XE_2D_U8x2x64_LD_N {
                                       intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_8b_2r32x2c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch, coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
           "Trying to use block prefetch on non-PVC hardware");
@@ -671,7 +671,7 @@ struct XE_2D_U8x4x64_LD_N {
                                       intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_8b_4r32x2c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch, coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
           "Trying to use block prefetch on non-PVC hardware");
@@ -703,7 +703,7 @@ struct XE_2D_U8x8x64_LD_N {
                                       intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_8b_8r32x2c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch, coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
           "Trying to use block prefetch on non-PVC hardware");
@@ -803,7 +803,7 @@ struct XE_2D_U8x32x16_LD_V {
                                       intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_8b_32r16x1c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch, coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
           "Trying to use block prefetch on non-PVC hardware");

--- a/include/cute/arch/xe_copy_2B.hpp
+++ b/include/cute/arch/xe_copy_2B.hpp
@@ -431,7 +431,7 @@ struct XE_2D_U16x1x32_LD_N {
                                       intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_16b_1r16x2c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch, coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
           "Trying to use block prefetch on non-PVC hardware");
@@ -463,7 +463,7 @@ struct XE_2D_U16x2x32_LD_N {
                                       intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_16b_2r16x2c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch, coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
           "Trying to use block prefetch on non-PVC hardware");
@@ -495,7 +495,7 @@ struct XE_2D_U16x4x32_LD_N {
                                       intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_16b_4r16x2c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch , coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
           "Trying to use block prefetch on non-PVC hardware");

--- a/include/cute/arch/xe_copy_4B.hpp
+++ b/include/cute/arch/xe_copy_4B.hpp
@@ -589,7 +589,7 @@ struct XE_2D_TF32x16x16_LD_N {
                                         intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_32b_16r8x1c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch, coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
               "Trying to use block prefetch on non-Xe hardware");
@@ -701,7 +701,7 @@ struct XE_2D_U32x16x8_LD_T {
                                       intel::coord_t coord) {
 #if defined(SYCL_INTEL_TARGET)
       intel_sub_group_2d_block_prefetch_32b_16r8x1c(
-          (__global void*)baseoffset, width - 1, height - 1, pitch - 1, coord);
+          (__global void*)baseoffset, width, height, pitch, coord);
 #else
       CUTE_INVALID_CONTROL_PATH(
           "Trying to use block prefetch on non-PVC hardware");


### PR DESCRIPTION
…n (the SPIR-V instruction is the same) is that the intrinsic mapped directly to the HW, so it needed the "-1", but the built-in function and the SPIR-V instruction should just take the width, height, and pitch as-is.

When we have the size 1 for the hight, the -1 was causing an issue on BMG making tests to fail. Since the openCL built-ins mainly used in prefetch it was causing segfault in the code when prefetch is used.