### PR TITLE
fixing the versioning

### DIFF
--- a/CHANGELOG-SYCL.md
+++ b/CHANGELOG-SYCL.md
@@ -1,7 +1,7 @@
 # SYCL CUTLASS Changelog
 
 ## [Cutlass 3.9 sycl backend version 0.1](https://github.com/codeplay/cutlass-fork/releases/tag/v3.9-0.1) (2025-04-30)
-- Support for Intel GPU data Centre Max (1100 and 1550) 
+- Support for Intel GPU Data Center Max (1100 and 1550) 
 - Support for Intel Arc B580 Battlemage 
 - GEMM/StreamK/SplitK with support for bfloat16 data type
 - Flash attention prefill and decode with KV cache with support for bfloat16 data type

--- a/CHANGELOG-SYCL.md
+++ b/CHANGELOG-SYCL.md
@@ -1,6 +1,6 @@
 # SYCL CUTLASS Changelog
 
-## [Cutlass 3.9 sycl backend version 0.1](https://github.com/codeplay/cutlass-fork/releases/tag/v3.9-0.1) (2025-04-30)
+## [Cutlass 3.9 SYCL backend Version 0.1](https://github.com/codeplay/cutlass-fork/releases/tag/v3.9-0.1) (2025-04-30)
 - Support for Intel GPU Data Center Max (1100 and 1550) 
 - Support for Intel Arc B580 Battlemage 
 - GEMM/StreamK/SplitK with support for bfloat16 data type

--- a/CHANGELOG-SYCL.md
+++ b/CHANGELOG-SYCL.md
@@ -1,7 +1,7 @@
 # SYCL CUTLASS Changelog
 
-## [Cutlass 3.8 sycl backend version 0.1](https://github.com/codeplay/cutlass-fork/releases/tag/v3.8-0.1) (2025-04-30)
-- Support for Intel GPU data Centre Max (1100  and 1550) 
+## [Cutlass 3.9 sycl backend version 0.1](https://github.com/codeplay/cutlass-fork/releases/tag/v3.9-0.1) (2025-04-30)
+- Support for Intel GPU data Centre Max (1100 and 1550) 
 - Support for Intel Arc B580 Battlemage 
 - GEMM/StreamK/SplitK with support for bfloat16 data type
 - Flash attention prefill and decode with KV cache with support for bfloat16 data type


### PR DESCRIPTION
The release is based on The CUTLASS [3.9.0](https://github.com/NVIDIA/cutlass/releases/tag/v3.9.0) (2025-03-20). 