### PR TITLE
Fix Windows native build

### DIFF
--- a/examples/sycl/02_pvc_gemm_mixed_dtype/CMakeLists.txt
+++ b/examples/sycl/02_pvc_gemm_mixed_dtype/CMakeLists.txt
@@ -26,20 +26,23 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(TEST_BATCHES --l=2)
-set(TEST_MODE_1 --l=2 --mode=1)
-set(TEST_MODE_0 --l=2 --mode=0)
-set(TEST_A_NARROW l=2 --a_narrower)
+# TODO(codeplay): Remove once IGC block load loop hoisting bug is fixed or a Windows work-around is available
+if(NOT WIN32)
+  set(TEST_BATCHES --l=2)
+  set(TEST_MODE_1 --l=2 --mode=1)
+  set(TEST_MODE_0 --l=2 --mode=0)
+  set(TEST_A_NARROW l=2 --a_narrower)
 
-cutlass_example_add_executable(
-  02_pvc_gemm_mixed_dtype
-  02_pvc_gemm_mixed_dtype.cpp
-  TEST_COMMAND_OPTIONS
-  TEST_BATCHES
-  TEST_MODE_1
-  TEST_MODE_0
-  TEST_A_NARROW
-)
+  cutlass_example_add_executable(
+    02_pvc_gemm_mixed_dtype
+    02_pvc_gemm_mixed_dtype.cpp
+    TEST_COMMAND_OPTIONS
+    TEST_BATCHES
+    TEST_MODE_1
+    TEST_MODE_0
+    TEST_A_NARROW
+  )
   # TODO(codeplay): Remove these once IGC block load loop hoisting bug is fixed
   set_target_properties( 02_pvc_gemm_mixed_dtype PROPERTIES CXX_COMPILER_LAUNCHER "IGC_allowDecompose2DBlockFuncs=0" )
   set_target_properties( 02_pvc_gemm_mixed_dtype PROPERTIES CXX_LINKER_LAUNCHER "IGC_allowDecompose2DBlockFuncs=0" )
+endif()

--- a/examples/sycl/03_pvc_gemm_streamk/CMakeLists.txt
+++ b/examples/sycl/03_pvc_gemm_streamk/CMakeLists.txt
@@ -35,5 +35,7 @@ cutlass_example_add_executable(
   TEST_BATCHES
 )
 # TODO(codeplay): Remove these once IGC VectorAliasThreshold issue is fixed
-set_target_properties( 03_pvc_gemm_streamk PROPERTIES CXX_COMPILER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
-set_target_properties( 03_pvc_gemm_streamk PROPERTIES CXX_LINKER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
+if(NOT WIN32)
+  set_target_properties( 03_pvc_gemm_streamk PROPERTIES CXX_COMPILER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
+  set_target_properties( 03_pvc_gemm_streamk PROPERTIES CXX_LINKER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
+endif()

--- a/examples/sycl/04_pvc_grouped_gemm/CMakeLists.txt
+++ b/examples/sycl/04_pvc_grouped_gemm/CMakeLists.txt
@@ -35,5 +35,7 @@ cutlass_example_add_executable(
   TEST_BATCHES
 )
 # TODO(codeplay): Remove these once IGC VectorAliasThreshold issue is fixed
-set_target_properties( 04_pvc_grouped_gemm PROPERTIES CXX_COMPILER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
-set_target_properties( 04_pvc_grouped_gemm PROPERTIES CXX_LINKER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
+if(NOT WIN32)
+  set_target_properties( 04_pvc_grouped_gemm PROPERTIES CXX_COMPILER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
+  set_target_properties( 04_pvc_grouped_gemm PROPERTIES CXX_LINKER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
+endif()

--- a/test/unit/cute/intel_xe/mma.cpp
+++ b/test/unit/cute/intel_xe/mma.cpp
@@ -89,9 +89,8 @@ void gemm_device(TA const *A, TB const *B, TC *C, uint32_t m, uint32_t n,
 
 #define CUTLASS_ENABLE_DEBUG_PRINTS (0)
 
-#define LOG_THREAD (16)
-
 #if CUTLASS_ENABLE_DEBUG_PRINTS
+#define LOG_THREAD (16)
   if (thread(LOG_THREAD)) {
     print("=====================  A :\n");
 


### PR DESCRIPTION
setting env-variable using `NAME=VALUE` in CXX_*_LAUNCHER is not portable and fails to run on Windows. Portable solution is to set it to `${CMAKE_COMMAND} -E env NAME=VALUE`. But IGC doesn't support reading those variables on Windows. Therefore just disable setting variables for Windows.