### PR TITLE
Enable IGC release on CI

### DIFF
--- a/.github/actions/install-dpcpp/action.yml
+++ b/.github/actions/install-dpcpp/action.yml
@@ -29,6 +29,8 @@ runs:
         if [[ "${{ inputs.GPU }}" == "BMG" ]]; then
           if [[ "${{ inputs.IGC }}" == "STAGING" ]]; then
             sudo add-apt-repository ppa:kobuk-team/intel-graphics-staging
+          else
+            sudo add-apt-repository ppa:kobuk-team/intel-graphics
           fi
           sudo apt-get install -y libze-intel-gpu1 libze1 intel-metrics-discovery intel-opencl-icd clinfo intel-gsc
           sudo apt-get install -y libze-dev intel-ocloc
@@ -66,6 +68,8 @@ runs:
         if [[ "${{ inputs.GPU }}" == "BMG" ]]; then
           if [[ "${{ inputs.IGC }}" == "STAGING" ]]; then
             sudo add-apt-repository ppa:kobuk-team/intel-graphics-staging
+          else
+            sudo add-apt-repository ppa:kobuk-team/intel-graphics
           fi
           sudo apt-get install -y libze-intel-gpu1 libze1 intel-metrics-discovery intel-opencl-icd clinfo intel-gsc
           sudo apt-get install -y libze-dev intel-ocloc

--- a/.github/workflows/intel_test.yml
+++ b/.github/workflows/intel_test.yml
@@ -34,6 +34,16 @@ jobs:
             intel_graphics: STAGING
             sycl_target: intel_gpu_bmg_g21
             runner: cp-b580-gpu
+          - compiler: RELEASE
+            gpu: BMG
+            intel_graphics: RELEASE
+            sycl_target: intel_gpu_bmg_g21
+            runner: cp-b580-gpu
+          - compiler: NIGHTLY
+            gpu: BMG
+            intel_graphics: RELEASE
+            sycl_target: intel_gpu_bmg_g21
+            runner: cp-b580-gpu
 
             # disable because IGC bug
 #          - compiler: NIGHTLY
@@ -46,16 +56,6 @@ jobs:
 #            intel_graphics: RELEASE
 #            sycl_target: intel_gpu_pvc
 #            runner: cp-gpumax-1100-gpu
-#          - compiler: RELEASE
-#            gpu: BMG
-#            intel_graphics: RELEASE
-#            sycl_target: intel_gpu_bmg_g21
-#            runner: cp-b580-gpu
-#          - compiler: NIGHTLY
-#            gpu: BMG
-#            intel_graphics: RELEASE
-#            sycl_target: intel_gpu_bmg_g21
-#            runner: cp-b580-gpu
 
     name: Run Intel ${{ matrix.compiler }} tests on ${{ matrix.gpu }} with intel-graphics ${{ matrix.intel_graphics }}
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
This PR enables the CI configurations to run the unit tests with the production drivers for BMG 