### PR TITLE
Collective builder for benchmarks

### DIFF
--- a/benchmarks/device/bmg/input_files/input_sglang_gemm.in
+++ b/benchmarks/device/bmg/input_files/input_sglang_gemm.in
@@ -20,6 +20,7 @@ PvcGemmBF16BF16FP32_RCR_5 --bm_name=mm_common --m=8 --k=4096 --n=4096
 # mm_silu 1,8 4096 14336
 PvcGemmBF16BF16FP32_RCR_8_silu --bm_name=mm_silu --m=1 --k=4096 --n=14336
 PvcGemmBF16BF16FP32_RCR_8_silu --bm_name=mm_silu --m=8 --k=4096 --n=14336
+PvcGemmCollectiveBF16BF16FP32_RCR_silu_8x64x32 --bm_name=mm_silu_collective --m=8 --k=4096 --n=14336
 
 # mm_mul 1,8 4096 14336
 PvcGemmBF16BF16FP32_RCR_7_mul --bm_name=mm_mul --m=1 --k=4096 --n=14336

--- a/benchmarks/device/pvc/input_files/input_gemm.in
+++ b/benchmarks/device/pvc/input_files/input_gemm.in
@@ -1,5 +1,6 @@
 # GEMM BFloat16 benchmarks
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=4096 --k=4096 --n=4096
+PvcGemmCollectiveBF16BF16FP32_RRR_256x256x32 --bm_name=bf16_bf16_fp32 --l=1 --m=4096 --k=4096 --n=4096
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=8192 --k=8192 --n=8192
 PvcGemmBF16BF16FP32_RRR_1 --bm_name=bf16_bf16_fp32 --l=1 --m=1 --k=5120 --n=13824
 PvcGemmBF16BF16FP32_RRR_2 --bm_name=bf16_bf16_fp32 --l=1 --m=1024 --k=28672 --n=8192

--- a/benchmarks/gemm/benchmarks_sycl.hpp
+++ b/benchmarks/gemm/benchmarks_sycl.hpp
@@ -48,8 +48,8 @@ using Gemm_Bench_BF16FP32_RRR = cutlass::gemm::device::GemmConfiguration<
     cutlass::bfloat16_t, cutlass::layout::RowMajor,
     float, cutlass::layout::RowMajor,
     float,
-    TileShape, Tiler, GmemTiledCopyA, GmemTiledCopyB,
-    Scheduler::Gemm>;
+    TileShape, Scheduler::Gemm, Tiler,
+    GmemTiledCopyA, GmemTiledCopyB>;
 
 
 using Tile_1 = TiledMMA<MMAAtom, Layout<Shape<_8,_4,_1>, Stride<_4,_1,_0>>, Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>, Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
@@ -84,8 +84,8 @@ using Gemm_Bench_BF16FP32_RCR = cutlass::gemm::device::GemmConfiguration<
     cutlass::bfloat16_t, cutlass::layout::ColumnMajor,
     float, cutlass::layout::RowMajor,
     float,
-    TileShape, Tiler, GmemTiledCopyA, GmemTiledCopyB,
-    Scheduler::Gemm>;
+    TileShape, Scheduler::Gemm, Tiler,
+    GmemTiledCopyA, GmemTiledCopyB>;
 
 using Tile_6 = TiledMMAHelper<MMAAtom, Layout<Shape<_8, _128, _32>>, Layout<Shape<_1, _4, _1>, Stride<_0, _1, _0>>>::TiledMMA;
 using PvcGemmBF16BF16FP32_RCR_5 = Gemm_Bench_BF16FP32_RCR<Shape<_8, _128, _32>, Tile_6, XE_2D_U16x8x32_LD_N, XE_2D_U16x16x16_LD_T>;
@@ -120,9 +120,8 @@ using SplitK_Bench_BF16FP32_RCR_Epilogue = cutlass::gemm::device::GemmConfigurat
     cutlass::bfloat16_t, cutlass::layout::ColumnMajor,
     float, cutlass::layout::RowMajor,
     float,
-    TileShape, Tiler, GmemTiledCopyA, GmemTiledCopyB,
-    Scheduler::GemmSplitK,
-    Epilogue>;
+    TileShape, Scheduler::GemmSplitK, Tiler,
+    GmemTiledCopyA, GmemTiledCopyB, Epilogue>;
 
 using Tile_10 = TiledMMAHelper<MMAAtom, Layout<Shape<_8, _64, _32>>, Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>>::TiledMMA;
 using PvcGemmBF16BF16FP32_RCR_8_silu = SplitK_Bench_BF16FP32_RCR_Epilogue<
@@ -150,20 +149,19 @@ using PvcGemmBF16BF16FP32_CRR_7 = cutlass::gemm::device::GemmConfiguration<
         cutlass::bfloat16_t, cutlass::layout::ColumnMajor,
         cutlass::bfloat16_t, cutlass::layout::RowMajor,
         float, cutlass::layout::RowMajor,
-        float, Shape<_256, _256, _32>,
-        Tile_1,
-        XE_2D_U16x16x16_LD_T, XE_2D_U16x32x32_LD_V,
-        Scheduler::Gemm>;
+        float,
+        Shape<_256, _256, _32>, Scheduler::Gemm, Tile_1,
+        XE_2D_U16x16x16_LD_T, XE_2D_U16x32x32_LD_V
+        >;
 
 using PvcGemmBF16BF16FP32_CCR_8 = cutlass::gemm::device::GemmConfiguration<
         cutlass::arch::IntelXe,
         cutlass::bfloat16_t, cutlass::layout::ColumnMajor,
         cutlass::bfloat16_t, cutlass::layout::ColumnMajor,
         float, cutlass::layout::RowMajor,
-        float, Shape<_256, _256, _32>,
-        Tile_1,
-        XE_2D_U16x16x16_LD_T, XE_2D_U16x16x16_LD_T,
-        Scheduler::Gemm>;
+        float,
+        Shape<_256, _256, _32>, Scheduler::Gemm, Tile_1,
+        XE_2D_U16x16x16_LD_T, XE_2D_U16x16x16_LD_T>;
 
 CUTLASS_CREATE_GEMM_BENCHMARK(PvcGemmBF16BF16FP32_CRR_7);
 CUTLASS_CREATE_GEMM_BENCHMARK(PvcGemmBF16BF16FP32_CCR_8);
@@ -218,10 +216,9 @@ using PvcGemmBF16BF16FP32_SplitK_RRR_1 = cutlass::gemm::device::GemmConfiguratio
         cutlass::bfloat16_t, cutlass::layout::RowMajor,
         cutlass::bfloat16_t, cutlass::layout::RowMajor,
         float, cutlass::layout::RowMajor,
-        float, Shape<_256, _256, _32>,
-        Tile_1,
-        XE_2D_U16x32x32_LD_N, XE_2D_U16x32x32_LD_V,
-        Scheduler::GemmSplitK>;
+        float,
+        Shape<_256, _256, _32>, Scheduler::GemmSplitK, Tile_1,
+        XE_2D_U16x32x32_LD_N, XE_2D_U16x32x32_LD_V>;
 
 using Tile_12 = TiledMMAHelper<MMAAtom, Layout<Shape<_8, _64, _32>>, Layout<Shape<_1, _4, _1>, Stride<_4, _1, _0>>>::TiledMMA;
 using PvcGemmBF16BF16FP32_SplitK_RCR_5 = cutlass::gemm::device::GemmConfiguration<
@@ -229,10 +226,9 @@ using PvcGemmBF16BF16FP32_SplitK_RCR_5 = cutlass::gemm::device::GemmConfiguratio
         cutlass::bfloat16_t, cutlass::layout::RowMajor,
         cutlass::bfloat16_t, cutlass::layout::ColumnMajor,
         float, cutlass::layout::RowMajor,
-        float, Shape<_8, _64, _32>,
-        Tile_12,
-        XE_2D_U16x8x32_LD_N, XE_2D_U16x16x16_LD_T,
-        Scheduler::GemmSplitK>;
+        float,
+        Shape<_8, _64, _32>, Scheduler::GemmSplitK, Tile_12,
+        XE_2D_U16x8x32_LD_N, XE_2D_U16x16x16_LD_T>;
 
 CUTLASS_CREATE_GEMM_BENCHMARK(PvcGemmBF16BF16FP32_SplitK_RRR_1);
 CUTLASS_CREATE_GEMM_BENCHMARK(PvcGemmBF16BF16FP32_SplitK_RCR_5);

--- a/benchmarks/gemm/gemm_configuration_sycl.hpp
+++ b/benchmarks/gemm/gemm_configuration_sycl.hpp
@@ -91,8 +91,6 @@ struct GemmConfiguration<
   using StrideB = std::conditional_t<cute::is_tuple_v<LayoutB>, LayoutB, TagToStrideB_t<LayoutB>>;
   using StrideC = std::conditional_t<cute::is_tuple_v<LayoutC>, LayoutC, TagToStrideC_t<LayoutC>>;
 
-  // TODO is this static assert needed?
-  static_assert(std::is_same_v<LayoutC, cutlass::layout::RowMajor>, "Column Major LayoutC unsupported in collective builder");
   using ClusterShape = Shape<_1, _1, _1>;
   static constexpr bool use_collective_mma_builder = std::is_void_v<TiledMma>;
   static_assert(

--- a/benchmarks/gemm/gemm_configuration_sycl.hpp
+++ b/benchmarks/gemm/gemm_configuration_sycl.hpp
@@ -41,6 +41,7 @@
 #include "cutlass/layout/layout.h"
 #include "cutlass/gemm/dispatch_policy.hpp"
 #include "cutlass/gemm/collective/collective_mma.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
 #include "cutlass/epilogue/collective/collective_builder.hpp"
 
 #include "cutlass/epilogue/collective/default_epilogue.hpp"
@@ -48,9 +49,7 @@
 
 using namespace cute;
 
-namespace cutlass {
-namespace gemm {
-namespace device {
+namespace cutlass::gemm::device {
 
 enum class Scheduler { Gemm, GemmSplitK, GemmStreamK };
 
@@ -60,9 +59,8 @@ template<
   class ElementB, class LayoutB,
   class ElementC, class LayoutC,
   class ElementAccumulator,
-  class TileShape, class TiledMma,
-  class GmemTiledCopyA, class GmemTiledCopyB,
-  Scheduler TileScheduler,
+  class TileShape, Scheduler TileScheduler, class TiledMma = void,
+  class GmemTiledCopyA = void, class GmemTiledCopyB = void,
   class EpilogueOp = epilogue::fusion::LinearCombination<float, float, float, float, FloatRoundStyle::round_to_nearest>>
 struct GemmConfiguration {
   static_assert(sizeof(ElementA) == 0, "No valid GemmConfiguration configuration exists.");
@@ -73,54 +71,67 @@ struct GemmConfiguration {
 // bfloat16
 
 template<typename LayoutA, typename LayoutB, typename LayoutC,
-  class TileShape, class TiledMma, class GmemTiledCopyA, class GmemTiledCopyB, Scheduler TileScheduler, class EpilogueOp>
+  class TileShape, Scheduler TileScheduler,
+  class TiledMma, class GmemTiledCopyA, class GmemTiledCopyB,  class EpilogueOp>
 struct GemmConfiguration<
       arch::IntelXe,
       bfloat16_t, LayoutA,
       bfloat16_t, LayoutB,
       float, LayoutC,
-      float, TileShape, TiledMma,
-      GmemTiledCopyA, GmemTiledCopyB, TileScheduler, EpilogueOp> {
-  using DispatchPolicy = MainloopIntelXeXMX16<3, std::conditional_t<TileScheduler == Scheduler::Gemm, cutlass::gemm::KernelXe, cutlass::gemm::KernelXeCooperative>>;
+      float,
+      TileShape, TileScheduler, TiledMma,
+      GmemTiledCopyA, GmemTiledCopyB, EpilogueOp>
+{
+  using KernelScheduleType = std::conditional_t<TileScheduler == Scheduler::Gemm,
+    cutlass::gemm::KernelXe, cutlass::gemm::KernelXeCooperative>;
+  using DispatchPolicy = MainloopIntelXeXMX16<3, KernelScheduleType>;
 
   // Configurations in benchmarks.hpp can pass either a layout tag (e.g. RowMajor) or a Stride directly
   using StrideA = std::conditional_t<cute::is_tuple_v<LayoutA>, LayoutA, TagToStrideA_t<LayoutA>>;
   using StrideB = std::conditional_t<cute::is_tuple_v<LayoutB>, LayoutB, TagToStrideB_t<LayoutB>>;
   using StrideC = std::conditional_t<cute::is_tuple_v<LayoutC>, LayoutC, TagToStrideC_t<LayoutC>>;
 
+  // TODO is this static assert needed?
+  static_assert(std::is_same_v<LayoutC, cutlass::layout::RowMajor>, "Column Major LayoutC unsupported in collective builder");
+  using ClusterShape = Shape<_1, _1, _1>;
+  static constexpr bool use_collective_mma_builder = std::is_void_v<TiledMma>;
+  static_assert(
+    use_collective_mma_builder == std::is_void_v<GmemTiledCopyA> and
+    use_collective_mma_builder == std::is_void_v<GmemTiledCopyB>,
+    "TiledMma, GmemTileCopyA, and GmemTileCopyB must be all void or none of them may be void."
+  );
   // Mainloop
-  using CollectiveMainloop = collective::CollectiveMma<
-    DispatchPolicy, TileShape,
-    bfloat16_t, StrideA,
-    bfloat16_t, StrideB,
-    TiledMma,
-    GmemTiledCopyA, void, void, identity, // A
-    GmemTiledCopyB, void, void, identity // B
-  >;
+  using CollectiveMainloop =
+    std::conditional_t<use_collective_mma_builder,
+      typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::IntelXe, cutlass::arch::OpClassTensorOp,
+        bfloat16_t, LayoutA, sizeof(bfloat16_t),
+        bfloat16_t, LayoutB, sizeof(bfloat16_t),
+        float,
+        TileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAuto,
+        KernelScheduleType
+      >::CollectiveOp,
+      collective::CollectiveMma<
+        DispatchPolicy, TileShape,
+        bfloat16_t, StrideA,
+        bfloat16_t, StrideB,
+        TiledMma,
+        GmemTiledCopyA, void, void, identity, // A
+        GmemTiledCopyB, void, void, identity // B
+  >>;
 
   // Epilogue
-  using EpilogueDispatchPolicy = epilogue::IntelXeXMX16;
-
-  // TODO(codeplay): Refactor this following Testbed3x approach. See benchmark_runner.hpp
-  using FusionCallBacks = std::conditional_t<
-      EpilogueOp::IsAuxInSupported, // ~Is mul_add
-      epilogue::fusion::FusionCallbacks<EpilogueDispatchPolicy, EpilogueOp, TileShape,
-                                        decltype(tile_shape(TiledMma())), XE_2D_U32x8x16_LD_N>,
-      epilogue::fusion::FusionCallbacks<EpilogueDispatchPolicy, EpilogueOp, TileShape,
-                                        decltype(tile_shape(TiledMma()))>>;
-
-  using CollectiveEpilogue = epilogue::collective::CollectiveEpilogue<
-        EpilogueDispatchPolicy,
-        TileShape,
-        float,
-        StrideC,
-        float,
-        StrideC,
-        FusionCallBacks,
-        XE_2D_U32x8x16_LD_N,
-        void, void,
-        XE_2D_U32x8x16_ST_N,
-        void, void>;
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::IntelXe, cutlass::arch::OpClassTensorOp,
+    TileShape, ClusterShape,
+    cutlass::epilogue::collective::EpilogueTileAuto, float,
+    float,
+    float, LayoutC, sizeof(float),
+    float, LayoutC, sizeof(float),
+    cutlass::epilogue::collective::EpilogueScheduleAuto,
+    EpilogueOp
+  >::CollectiveOp;
 
   using GemmKernel = kernel::GemmUniversal<
     Shape<int, int, int, int>,
@@ -149,6 +160,4 @@ struct GemmConfiguration<
   }
 };
 
-} // namespace device
-} // namespace gemm
-} // namespace cutlass
+} // namespace cutlass::gemm::device


### PR DESCRIPTION
Depends on #372.

Adds the option to use the collective builder for benchmarks.
The order of arguments for the benchmark configurations was rearranged to allow for some arguments to not be specified.