### PR TITLE
Investigate Python test CI failures

### DIFF
--- a/.github/workflows/sycl_python_test.yml
+++ b/.github/workflows/sycl_python_test.yml
@@ -72,4 +72,5 @@ jobs:
           source ~/.venv/bin/activate
           pip install -e .
           export CUTLASS_USE_SYCL=1
+          export SYCL_UR_TRACE=2
           python test/python/cutlass/gemm/run_all_tests.py


### PR DESCRIPTION
Enable UR tracing when running Python interface tests in the CI workflow to get additional information if the CI workflow fails.