### PR TITLE
Add ONEAPI_DEVICE_SELECTOR to workflow

### DIFF
--- a/.github/workflows/sycl_python_test.yml
+++ b/.github/workflows/sycl_python_test.yml
@@ -73,4 +73,5 @@ jobs:
           pip install -e .
           export CUTLASS_USE_SYCL=1
           export SYCL_UR_TRACE=2
+          export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
           python test/python/cutlass/gemm/run_all_tests.py


### PR DESCRIPTION
Explicitly set the `ONEAPI_DEVICE_SELECTOR` to LevelZero GPUs in the CUTLASS Python interface test workflow.