### PR TITLE
Separate Accumulation and Output type for Flash Attention Decode

### DIFF
--- a/applications/flash_attention_v2/kernel/xe_flash_attn_decode.hpp
+++ b/applications/flash_attention_v2/kernel/xe_flash_attn_decode.hpp
@@ -386,7 +386,7 @@ public:
           CUTLASS_PRAGMA_UNROLL
           for (int n = 0; n < FragsN; n++, col_idx += get<1>(MmaAtomShape())) { // 4
             if (col_idx - column_offset > row_idx + seq_len_kv_cache) {
-              tSr(0, 0, n) = -INFINITY;
+              tSr(0, 0, n) = ElementAccumulator{-INFINITY};
             }
           }
         }

--- a/benchmarks/flash_attention/flash_attention_decode/benchmark_runner.hpp
+++ b/benchmarks/flash_attention/flash_attention_decode/benchmark_runner.hpp
@@ -207,7 +207,7 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
       int seq_len_kv_total = seq_len_kv_cache + seq_len_kv;
       int kv_group_update = 1;
       for (int h = 0; h < num_heads_q; h++) {
-        cutlass::DeviceAllocation<ElementOutput> block_S;
+        cutlass::DeviceAllocation<ElementAccumulator> block_S;
         block_S.reset(seq_len_qo * seq_len_kv_total);
 
         ElementK* k_ptr;
@@ -254,11 +254,10 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
         cutlass::TensorRef ref_K(k_ptr, LayoutK::packed({head_size_qk, seq_len_kv_total}));
         cutlass::TensorRef ref_V(v_ptr, LayoutV::packed({seq_len_kv_total, head_size_vo}));
         cutlass::TensorRef ref_S(block_S.get(), LayoutQ::packed({seq_len_qo, seq_len_kv_total}));
-        cutlass::TensorRef ref_O(block_ref_O.get() + offset_o, LayoutO::packed({seq_len_qo, head_size_vo}));
 
-        cutlass::reference::device::GemmComplex({seq_len_qo, seq_len_kv_total, head_size_qk}, 1.f, ref_Q,
+        cutlass::reference::device::GemmComplex({seq_len_qo, seq_len_kv_total, head_size_qk}, ElementAccumulator{1}, ref_Q,
                                                 cutlass::ComplexTransform::kNone, ref_K, cutlass::ComplexTransform::kNone,
-                                                0.f, ref_S, ref_S, ElementAccumulator(0),
+                                                ElementAccumulator{0}, ref_S, ref_S, ElementAccumulator{0},
                                                 1,                   // batch_count
                                                 seq_len_qo * head_size_qk, // batch_stride_Q
                                                 seq_len_kv_total * head_size_qk, // batch_stride_K
@@ -268,8 +267,8 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
 
         syclcompat::wait();
 
-        std::vector<ElementOutput> host_S(block_S.size());
-        syclcompat::memcpy<ElementOutput>(host_S.data(), block_S.get(), host_S.size());
+        std::vector<ElementAccumulator> host_S(block_S.size());
+        syclcompat::memcpy<ElementAccumulator>(host_S.data(), block_S.get(), host_S.size());
         syclcompat::wait();
 
         // delete this memory as it is no longer needed
@@ -283,13 +282,13 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
           for (int row = 0; row < seq_len_qo; row++) {
             for (int col = seq_len_kv_cache; col < seq_len_kv_total; col++) {
               if ((col - full_tile_offset) > (row + seq_len_kv_cache - discard_seq_coord))
-                host_S[col + row * seq_len_kv_total] = -INFINITY;
+                host_S[col + row * seq_len_kv_total] = ElementAccumulator{-INFINITY};
             }
           }
         }
 
         // compute max element per row of S
-        std::vector<ElementOutput> max_vec(seq_len_qo, -INFINITY);
+        std::vector<ElementAccumulator> max_vec(seq_len_qo, ElementAccumulator{-INFINITY});
         for (int row = 0; row < seq_len_qo; row++) {
           int idx = row * seq_len_kv_total;
           int max_idx = row;
@@ -305,12 +304,12 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
           int idx = row * seq_len_kv_total;
           int max_idx = row;
           for (int col = 0; col < seq_len_kv_total; col++, idx++) {
-            host_S[idx] = expf((host_S[idx] - max_vec[max_idx]) / std::sqrt(static_cast<ElementOutput>((head_size_qk))));
+            host_S[idx] = expf((host_S[idx] - max_vec[max_idx]) / std::sqrt(static_cast<ElementAccumulator>((head_size_qk))));
           }
         }
 
         // compute sum per row of S
-        std::vector<ElementOutput> sum_vec(seq_len_qo, ElementOutput{0});
+        std::vector<ElementAccumulator> sum_vec(seq_len_qo, ElementAccumulator{0});
         for (int row = 0; row < seq_len_qo; row++) {
           int idx = row * seq_len_kv_total;
           int sum_idx = row;
@@ -342,9 +341,13 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
 
         cutlass::TensorRef ref_P(block_P.get(), LayoutQ::packed({seq_len_qo, seq_len_kv_total}));
 
-        cutlass::reference::device::GemmComplex({seq_len_qo, head_size_vo, seq_len_kv_total}, 1.f, ref_P,
+        cutlass::DeviceAllocation<ElementAccumulator> block_acc;
+        block_acc.reset(seq_len_qo * head_size_vo);
+        cutlass::TensorRef ref_acc(block_acc.get(), LayoutO::packed({seq_len_qo, head_size_vo}));
+
+        cutlass::reference::device::GemmComplex({seq_len_qo, head_size_vo, seq_len_kv_total}, ElementAccumulator{1}, ref_P,
                                                 cutlass::ComplexTransform::kNone, ref_V, cutlass::ComplexTransform::kNone,
-                                                0.f, ref_O, ref_O, ElementAccumulator(0),
+                                                ElementAccumulator{0}, ref_acc, ref_acc, ElementAccumulator{0},
                                                 1,                   // batch_count
                                                 seq_len_qo * seq_len_kv_total,   // batch_stride_P
                                                 seq_len_kv_total * head_size_vo, // batch_stride_V
@@ -355,6 +358,19 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
         syclcompat::wait();
         // delete this memory as it is no longer needed
         block_P.reset();
+
+        std::vector<ElementAccumulator> vec_acc(block_acc.size());
+        syclcompat::memcpy<ElementAccumulator>(vec_acc.data(), block_acc.get(), vec_acc.size());
+        syclcompat::wait();
+
+        // delete this memory as it is no longer needed
+        block_acc.reset();
+        std::vector<ElementOutput> vec_out(vec_acc.size());
+        for(int i = 0; i < vec_out.size(); i++) {
+          vec_out[i] = static_cast<ElementOutput>(vec_acc[i]);
+        }
+        syclcompat::memcpy<ElementOutput>(block_ref_O.get() + offset_o, vec_out.data(), vec_out.size());
+        syclcompat::wait();
 
         offset_q += seq_len_qo * head_size_qk;
         if(kv_group_update % q_group_size == 0) {
@@ -372,7 +388,7 @@ template <class FMHADecodeConfiguration> struct BenchmarkRunnerFMHADecode {
 
     // Check if output from CUTLASS kernel and reference kernel are equal or not
     bool passed = cutlass::reference::device::BlockCompareRelativelyEqual(block_ref_O.get(), block_O.get(),
-                                                                          block_O.size(), 0.5f, 0.5f);
+                                                                          block_O.size(), ElementOutput{0.5}, ElementOutput{0.5});
 
     return passed;
   }

--- a/benchmarks/flash_attention/flash_attention_decode/benchmarks_h128_1024.hpp
+++ b/benchmarks/flash_attention/flash_attention_decode/benchmarks_h128_1024.hpp
@@ -33,15 +33,15 @@
 
 using namespace cutlass::flash_attention;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h128_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, false, Shape_h128<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h128_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, true, Shape_h128<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h128_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, false, Shape_h128<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h128_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, true, Shape_h128<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h128_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, false, Shape_h128<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h128_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, true, Shape_h128<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h128_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, false, Shape_h128<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h128_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, true, Shape_h128<1024, 16>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h128_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  true, false, Shape_h128<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h128_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  true, true, Shape_h128<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h128_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  false, false, Shape_h128<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h128_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  false, true, Shape_h128<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h128_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, false, Shape_h128<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h128_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, true, Shape_h128<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h128_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, false, Shape_h128<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h128_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, true, Shape_h128<1024, 16>>::type;
 
 
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h128_Causal_FixedLen);

--- a/benchmarks/flash_attention/flash_attention_decode/benchmarks_h128_512.hpp
+++ b/benchmarks/flash_attention/flash_attention_decode/benchmarks_h128_512.hpp
@@ -33,17 +33,17 @@
 
 using namespace cutlass::flash_attention;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, false, Shape_h128<512, 8>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, true, Shape_h128<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, false, Shape_h128<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, true, Shape_h128<512, 8>>::type;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, false, Shape_h128<512, 8>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, true, Shape_h128<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, false, Shape_h128<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, true, Shape_h128<512, 8>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h128_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  true, false, Shape_h128<512, 8>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h128_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  true, true, Shape_h128<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h128_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, false, Shape_h128<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h128_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, true, Shape_h128<512, 8>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h128_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  false, false, Shape_h128<512, 8>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h128_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  false, true, Shape_h128<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h128_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, false, Shape_h128<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h128_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, true, Shape_h128<512, 8>>::type;
 
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_Causal_FixedLen);
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h128_NonCausal_FixedLen);

--- a/benchmarks/flash_attention/flash_attention_decode/benchmarks_h192_1024.hpp
+++ b/benchmarks/flash_attention/flash_attention_decode/benchmarks_h192_1024.hpp
@@ -33,15 +33,15 @@
 
 using namespace cutlass::flash_attention;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h192_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, false, Shape_h192<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h192_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, true, Shape_h192<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h192_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, false, Shape_h192<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h192_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, true, Shape_h192<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h192_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, false, Shape_h192<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h192_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, true, Shape_h192<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h192_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, false, Shape_h192<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h192_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, true, Shape_h192<1024, 16>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h192_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  true, false, Shape_h192<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h192_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  true, true, Shape_h192<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h192_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  false, false, Shape_h192<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h192_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  false, true, Shape_h192<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h192_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, false, Shape_h192<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h192_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, true, Shape_h192<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h192_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, false, Shape_h192<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h192_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, true, Shape_h192<1024, 16>>::type;
 
 
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h192_Causal_FixedLen);

--- a/benchmarks/flash_attention/flash_attention_decode/benchmarks_h192_512.hpp
+++ b/benchmarks/flash_attention/flash_attention_decode/benchmarks_h192_512.hpp
@@ -33,17 +33,17 @@
 
 using namespace cutlass::flash_attention;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, false, Shape_h192<512, 8>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, true, Shape_h192<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, false, Shape_h192<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, true, Shape_h192<512, 8>>::type;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, false, Shape_h192<512, 8>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, true, Shape_h192<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, false, Shape_h192<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, true, Shape_h192<512, 8>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h192_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  true, false, Shape_h192<512, 8>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h192_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  true, true, Shape_h192<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h192_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, false, Shape_h192<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h192_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, true, Shape_h192<512, 8>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h192_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  false, false, Shape_h192<512, 8>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h192_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  false, true, Shape_h192<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h192_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, false, Shape_h192<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h192_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, true, Shape_h192<512, 8>>::type;
 
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_Causal_FixedLen);
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h192_NonCausal_FixedLen);

--- a/benchmarks/flash_attention/flash_attention_decode/benchmarks_h64_1024.hpp
+++ b/benchmarks/flash_attention/flash_attention_decode/benchmarks_h64_1024.hpp
@@ -33,17 +33,17 @@
 
 using namespace cutlass::flash_attention;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, false, Shape_h64<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, true, Shape_h64<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, false, Shape_h64<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, true, Shape_h64<1024, 16>>::type;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, false, Shape_h64<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, true, Shape_h64<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, false, Shape_h64<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, true, Shape_h64<1024, 16>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h64_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  true, false, Shape_h64<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h64_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  true, true, Shape_h64<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h64_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, false, Shape_h64<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h64_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, true, Shape_h64<1024, 16>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h64_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  false, false, Shape_h64<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h64_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  false, true, Shape_h64<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h64_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, false, Shape_h64<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h64_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, true, Shape_h64<1024, 16>>::type;
 
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_Causal_FixedLen);
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h64_NonCausal_FixedLen);

--- a/benchmarks/flash_attention/flash_attention_decode/benchmarks_h64_512.hpp
+++ b/benchmarks/flash_attention/flash_attention_decode/benchmarks_h64_512.hpp
@@ -33,17 +33,17 @@
 
 using namespace cutlass::flash_attention;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h64_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, false, Shape_h64<512, 8>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h64_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, true, Shape_h64<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h64_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, false, Shape_h64<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h64_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, true, Shape_h64<512, 8>>::type;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h64_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, false, Shape_h64<512, 8>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h64_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, true, Shape_h64<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h64_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, false, Shape_h64<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h64_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, true, Shape_h64<512, 8>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h64_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  true, false, Shape_h64<512, 8>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h64_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  true, true, Shape_h64<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h64_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, false, Shape_h64<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h64_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, true, Shape_h64<512, 8>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h64_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  false, false, Shape_h64<512, 8>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h64_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  false, true, Shape_h64<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h64_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, false, Shape_h64<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h64_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, true, Shape_h64<512, 8>>::type;
 
 
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h64_Causal_FixedLen);

--- a/benchmarks/flash_attention/flash_attention_decode/benchmarks_h96_1024.hpp
+++ b/benchmarks/flash_attention/flash_attention_decode/benchmarks_h96_1024.hpp
@@ -33,15 +33,15 @@
 
 using namespace cutlass::flash_attention;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h96_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, false, Shape_h96<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h96_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, true, Shape_h96<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h96_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, false, Shape_h96<1024, 16>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h96_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, true, Shape_h96<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h96_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, false, Shape_h96<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h96_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, true, Shape_h96<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h96_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, false, Shape_h96<1024, 16>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h96_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, true, Shape_h96<1024, 16>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h96_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  true, false, Shape_h96<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h96_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  true, true, Shape_h96<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h96_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  false, false, Shape_h96<1024, 16>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h96_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  false, true, Shape_h96<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h96_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, false, Shape_h96<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h96_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, true, Shape_h96<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h96_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, false, Shape_h96<1024, 16>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile1024_h96_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, true, Shape_h96<1024, 16>>::type;
 
 
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile1024_h96_Causal_FixedLen);

--- a/benchmarks/flash_attention/flash_attention_decode/benchmarks_h96_512.hpp
+++ b/benchmarks/flash_attention/flash_attention_decode/benchmarks_h96_512.hpp
@@ -33,17 +33,17 @@
 
 using namespace cutlass::flash_attention;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, false, Shape_h96<512, 8>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  true, true, Shape_h96<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_Causal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, false, Shape_h96<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_Causal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  true, true, Shape_h96<512, 8>>::type;
 
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, false, Shape_h96<512, 8>>::type;
-using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t,  false, true, Shape_h96<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, false, Shape_h96<512, 8>>::type;
+using PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::bfloat16_t, float, float,  false, true, Shape_h96<512, 8>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h96_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  true, false, Shape_h96<512, 8>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h96_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  true, true, Shape_h96<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h96_Causal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, false, Shape_h96<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h96_Causal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  true, true, Shape_h96<512, 8>>::type;
 
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h96_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t,  false, false, Shape_h96<512, 8>>::type;
-using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h96_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t,  false, true, Shape_h96<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h96_NonCausal_FixedLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, false, Shape_h96<512, 8>>::type;
+using PvcFMHADecodeFP16FP16FP32_RCR_KVTile512_h96_NonCausal_VarLen = FMHADecodeConfigGen<cutlass::half_t, float, float,  false, true, Shape_h96<512, 8>>::type;
 
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_Causal_FixedLen);
 CUTLASS_CREATE_FMHA_DECODE_BENCHMARK(PvcFMHADecodeBF16BF16FP32_RCR_KVTile512_h96_NonCausal_FixedLen);

--- a/examples/sycl/06_bmg_flash_attention/bmg_flash_attn_decode_runner.hpp
+++ b/examples/sycl/06_bmg_flash_attention/bmg_flash_attn_decode_runner.hpp
@@ -222,7 +222,7 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
       int seq_len_kv_total = seq_len_kv_cache + seq_len_kv;
       int kv_group_update = 1;
       for (int h = 0; h < num_heads_q; h++) {
-        cutlass::DeviceAllocation<ElementOutput> block_S;
+        cutlass::DeviceAllocation<ElementAccumulator> block_S;
         block_S.reset(seq_len_qo * seq_len_kv_total);
 
         ElementK* k_ptr;
@@ -269,11 +269,10 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
         cutlass::TensorRef ref_K(k_ptr, LayoutK::packed({head_size_qk, seq_len_kv_total}));
         cutlass::TensorRef ref_V(v_ptr, LayoutV::packed({seq_len_kv_total, head_size_vo}));
         cutlass::TensorRef ref_S(block_S.get(), LayoutQ::packed({seq_len_qo, seq_len_kv_total}));
-        cutlass::TensorRef ref_O(block_ref_O.get() + offset_o, LayoutO::packed({seq_len_qo, head_size_vo}));
 
-        cutlass::reference::device::GemmComplex({seq_len_qo, seq_len_kv_total, head_size_qk}, 1.f, ref_Q,
+        cutlass::reference::device::GemmComplex({seq_len_qo, seq_len_kv_total, head_size_qk}, ElementAccumulator{1}, ref_Q,
                                                 cutlass::ComplexTransform::kNone, ref_K, cutlass::ComplexTransform::kNone,
-                                                0.f, ref_S, ref_S, ElementAccumulator(0),
+                                                ElementAccumulator{0}, ref_S, ref_S, ElementAccumulator{0},
                                                 1,                   // batch_count
                                                 seq_len_qo * head_size_qk, // batch_stride_Q
                                                 seq_len_kv_total * head_size_qk, // batch_stride_K
@@ -283,8 +282,8 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
 
         syclcompat::wait();
 
-        std::vector<ElementOutput> host_S(block_S.size());
-        syclcompat::memcpy<ElementOutput>(host_S.data(), block_S.get(), host_S.size());
+        std::vector<ElementAccumulator> host_S(block_S.size());
+        syclcompat::memcpy<ElementAccumulator>(host_S.data(), block_S.get(), host_S.size());
         syclcompat::wait();
 
         // delete this memory as it is no longer needed
@@ -299,13 +298,13 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
           for (int row = 0; row < seq_len_qo; row++) {
             for (int col = start_col; col < seq_len_kv_total; col++) {
               if (col - full_tile_offset > row + start_col - discard_seq_coord)
-                host_S[col + row * seq_len_kv_total] = -INFINITY;
+                host_S[col + row * seq_len_kv_total] = ElementAccumulator{-INFINITY};
             }
           }
         }
 
         // compute max element per row of S
-        std::vector<ElementOutput> max_vec(seq_len_qo, -INFINITY);
+        std::vector<ElementAccumulator> max_vec(seq_len_qo, ElementAccumulator{-INFINITY});
         for (int row = 0; row < seq_len_qo; row++) {
           int idx = row * seq_len_kv_total;
           int max_idx = row;
@@ -321,12 +320,12 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
           int idx = row * seq_len_kv_total;
           int max_idx = row;
           for (int col = 0; col < seq_len_kv_total; col++, idx++) {
-            host_S[idx] = expf((host_S[idx] - max_vec[max_idx]) / sqrt(static_cast<ElementOutput>((head_size_qk))));
+            host_S[idx] = expf((host_S[idx] - max_vec[max_idx]) / sqrt(static_cast<ElementAccumulator>((head_size_qk))));
           }
         }
 
         // compute sum per row of S
-        std::vector<ElementOutput> sum_vec(seq_len_qo, ElementOutput{0});
+        std::vector<ElementAccumulator> sum_vec(seq_len_qo, ElementAccumulator{0});
         for (int row = 0; row < seq_len_qo; row++) {
           int idx = row * seq_len_kv_total;
           int sum_idx = row;
@@ -358,9 +357,13 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
 
         cutlass::TensorRef ref_P(block_P.get(), LayoutQ::packed({seq_len_qo, seq_len_kv_total}));
 
-        cutlass::reference::device::GemmComplex({seq_len_qo, head_size_vo, seq_len_kv_total}, 1.f, ref_P,
+        cutlass::DeviceAllocation<ElementAccumulator> block_acc;
+        block_acc.reset(seq_len_qo * head_size_vo);
+        cutlass::TensorRef ref_acc(block_acc.get(), LayoutO::packed({seq_len_qo, head_size_vo}));
+
+        cutlass::reference::device::GemmComplex({seq_len_qo, head_size_vo, seq_len_kv_total}, ElementAccumulator{1}, ref_P,
                                                 cutlass::ComplexTransform::kNone, ref_V, cutlass::ComplexTransform::kNone,
-                                                0.f, ref_O, ref_O, ElementAccumulator(0),
+                                                ElementAccumulator{0}, ref_acc, ref_acc, ElementAccumulator{0},
                                                 1,                   // batch_count
                                                 seq_len_qo * seq_len_kv_total,   // batch_stride_P
                                                 seq_len_kv_total * head_size_vo, // batch_stride_V
@@ -371,6 +374,19 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
         syclcompat::wait();
         // delete this memory as it is no longer needed
         block_P.reset();
+
+        std::vector<ElementAccumulator> vec_acc(block_acc.size());
+        syclcompat::memcpy<ElementAccumulator>(vec_acc.data(), block_acc.get(), vec_acc.size());
+        syclcompat::wait();
+
+        // delete this memory as it is no longer needed
+        block_acc.reset();
+        std::vector<ElementOutput> vec_out(vec_acc.size());
+        for(int i = 0; i < vec_out.size(); i++) {
+          vec_out[i] = static_cast<ElementOutput>(vec_acc[i]);
+        }
+        syclcompat::memcpy<ElementOutput>(block_ref_O.get() + offset_o, vec_out.data(), vec_out.size());
+        syclcompat::wait();
 
         offset_q += seq_len_qo * head_size_qk;
         if(kv_group_update % q_group_size == 0) {
@@ -388,7 +404,7 @@ template <class FMHAKernel, bool isVarLen> struct ExampleRunner {
 
     // Check if output from CUTLASS kernel and reference kernel are equal or not
     bool passed = cutlass::reference::device::BlockCompareRelativelyEqual(block_ref_O.get(), block_O.get(),
-                                                                          block_O.size(), 0.5f, 0.5f);
+                                                                          block_O.size(), ElementOutput{0.5}, ElementOutput{0.5});
 
     return passed;
   }
@@ -664,7 +680,7 @@ template <bool Causal, typename TileShapeQK, typename TileShapePV, typename Tile
     using ElementInputQ = bfloat16_t;     // <- data type of elements in input matrix A
     using ElementInputKV = bfloat16_t;    // <- data type of elements in input matrix B
     using ElementOutput = float;          // <- data type of elements in output matrix D
-        
+
     constexpr int PipelineStages = 2;
     using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelXeXMX16<PipelineStages>;
     using EpilogueDispatchPolicy = cutlass::epilogue::IntelXeXMX16;
@@ -675,7 +691,7 @@ template <bool Causal, typename TileShapeQK, typename TileShapePV, typename Tile
     using GmemTiledCopyV = XE_2D_U16x32x32_LD_V;
     using GmemTiledCopyStore = XE_2D_U32x1x16_ST_N;
     using CollectiveEpilogue = cutlass::flash_attention::collective::FlashDecodeEpilogue<
-        EpilogueDispatchPolicy, MMAOperation, TileShapeOutput, SubgroupLayout, ElementAccumulator, cutlass::gemm::TagToStrideC_t<LayoutO>,
+        EpilogueDispatchPolicy, MMAOperation, TileShapeOutput, SubgroupLayout, ElementComputeEpilogue, ElementOutput, cutlass::gemm::TagToStrideC_t<LayoutO>,
         ElementOutput, GmemTiledCopyStore>;
     using CollectiveSoftmaxEpilogue = cutlass::flash_attention::collective::FlashDecodeSoftmaxEpilogue<Causal, EpilogueDispatchPolicy, ElementAccumulator>;
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h128_1024.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h128_1024.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationBF16 = test::flash_attention::MMAOperationBF16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h128<1024, 16>;
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h128, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h128, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h128, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h128, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h128_512.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h128_512.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationBF16 = test::flash_attention::MMAOperationBF16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h128<512, 8>;
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h128, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h128, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h128, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h128, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h192_1024.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h192_1024.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationBF16 = test::flash_attention::MMAOperationBF16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h192<1024, 16>;
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h192, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h192, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h192, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h192, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h192_512.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h192_512.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationBF16 = test::flash_attention::MMAOperationBF16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h192<512, 8>;
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h192, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h192, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h192, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h192, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h64_1024.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h64_1024.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationBF16 = test::flash_attention::MMAOperationBF16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h64<1024, 16>;
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h64, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h64, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h64, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h64, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h64_512.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h64_512.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationBF16 = test::flash_attention::MMAOperationBF16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h64<512, 8>;
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h64, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h64, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h64, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h64, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h96_1024.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h96_1024.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationBF16 = test::flash_attention::MMAOperationBF16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h96<1024, 16>;
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h96, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h96, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h96, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile1024_h96, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h96_512.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_bf16_fp32_fp32_h96_512.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationBF16 = test::flash_attention::MMAOperationBF16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h96<512, 8>;
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h96, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h96, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h96, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_bf16_fp32_fp32_KVTile512_h96, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<bfloat16_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationBF16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h128_1024.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h128_1024.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationFP16 = test::flash_attention::MMAOperationFP16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h128<1024, 16>;
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h128, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h128, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h128, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h128, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h128_512.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h128_512.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationFP16 = test::flash_attention::MMAOperationFP16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h128<512, 8>;
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h128, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h128, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h128, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h128, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(128));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h192_1024.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h192_1024.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationFP16 = test::flash_attention::MMAOperationFP16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h192<1024, 16>;
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h192, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h192, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h192, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h192, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h192_512.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h192_512.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationFP16 = test::flash_attention::MMAOperationFP16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h192<512, 8>;
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h192, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h192, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h192, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h192, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(192));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h64_1024.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h64_1024.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationFP16 = test::flash_attention::MMAOperationFP16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h64<1024, 16>;
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h64, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h64, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h64, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h64, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h64_512.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h64_512.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationFP16 = test::flash_attention::MMAOperationFP16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h64<512, 8>;
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h64, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h64, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h64, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h64, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(64));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h96_1024.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h96_1024.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationFP16 = test::flash_attention::MMAOperationFP16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h96<1024, 16>;
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h96, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h96, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h96, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile1024_h96, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 

--- a/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h96_512.cpp
+++ b/test/unit/flash_attention/flash_attention_decode/xe_flash_decode_fp16_fp32_fp32_h96_512.cpp
@@ -38,29 +38,37 @@
 namespace cutlass {
 
 using MMAOperationFP16 = test::flash_attention::MMAOperationFP16;
+using GmemTiledCopyQ = test::flash_attention::GmemTiledCopyQU16;
+using GmemTiledCopyK = test::flash_attention::GmemTiledCopyKU16;
+using GmemTiledCopyV = test::flash_attention::GmemTiledCopyVU16;
+using GmemTiledCopyStore = test::flash_attention::GmemTiledCopyStoreU32;
 using Shape_h = test::flash_attention::Shape_h96<512, 8>;
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h96, causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h96, noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, false,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h96, varlen_causal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, true, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 
 TEST(XE_Flash_Attention_Decode_fp16_fp32_fp32_KVTile512_h96, varlen_noncausal) {
   using Kernel = test::flash_attention::XE_Flash_Attention_Decode<half_t, float, float, typename Shape_h::ShapeQK, typename Shape_h::ShapePV,
-                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true>::Kernel;
+                                            typename Shape_h::ShapeOutput, typename Shape_h::SubgroupLayout, MMAOperationFP16, false, true,
+                                            GmemTiledCopyQ, GmemTiledCopyK, GmemTiledCopyV, GmemTiledCopyStore>::Kernel;
   EXPECT_TRUE(test::flash_attention::TestFlashDecodeAll<Kernel>(96));
 }
 


### PR DESCRIPTION
This PR allows different data types for accumulation and the actual output stored to Global Memory. It supports the following combinations:
* Input = bf16 | fp16, Accumulator = fp32, Output = fp32
* Input = bf16 | fp16, Accumulator = fp32, Output = bf16 | fp16 respectively