### PR TITLE
Workaround to skip today's DPCPP nightly on CI

### DIFF
--- a/.github/workflows/intel_test.yml
+++ b/.github/workflows/intel_test.yml
@@ -70,7 +70,7 @@ jobs:
         uses: ./.github/actions/install-dpcpp
         with:
           DPCPP_RELEASE: ${{ matrix.compiler }}
-          DPCPP_VERSION: ${{ inputs.DPCPP_VERSION }}
+          DPCPP_VERSION: nightly-2025-06-10
           GPU: ${{ matrix.gpu }}
           IGC: ${{ matrix.intel_graphics }}
       - name: Setup virtual environment

--- a/.github/workflows/sycl_python_test.yml
+++ b/.github/workflows/sycl_python_test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ./.github/actions/install-dpcpp
         with:
           # DPCPP_RELEASE: ${{ matrix.compiler }}
-          DPCPP_VERSION: ${{ inputs.DPCPP_VERSION }}
+          DPCPP_VERSION: nightly-2025-06-10
           DPCPP_PATH: ~/dpcpp
       - name: Setup virtual environment
         shell: bash


### PR DESCRIPTION
This is needed because today's release does not include the binaries used for CI