### PR TITLE
Create a helper for constructing tiled copies of default size

### DIFF
--- a/include/cute/atom/copy_traits_xe.hpp
+++ b/include/cute/atom/copy_traits_xe.hpp
@@ -291,9 +291,9 @@ CUTE_HOST_DEVICE auto prefetch_selector(TiledCopy<TiledCopyArgs...> const& tiled
 
 template <class CopyOp, class StrideOrTensor = cute::Stride<int64_t, cute::Int<1>, int64_t>>
 struct XE_2D_LD_Unpack {
-  using BlockShape = typename CopyOp::BlockShape;
+  using BlockShape = typename CopyOp::BlockShape; // this is not the same as Traits_LD_t::BlockShape iff is_matrix_B
   using Traits_LD_t = Copy_Traits<CopyOp, StrideOrTensor>;
-
+ 
   static constexpr auto stride_rank = rank(StrideOrTensor{});
   static_assert(stride_rank == 2 || stride_rank == 3);
 
@@ -307,6 +307,13 @@ struct XE_2D_LD_Unpack {
   // For matrix B cute internally has transposed representation compared to other matrices, for cute its shape is (N,K)
   // Intel copy instructions, on the other hand follow blas convention, where matrix B has shape (K,N)
   static constexpr bool is_matrix_B = is_tensor_M_major ^ is_transpose_copy;
+  
+  using CopyThreadShape = Shape<_1, Int<detail::subgroup_size>>;
+  // we can not use Traits_LD_t::BlockShape as this is a parent class of Traits_LD_t, so that would be recursion. Recalculate it instead.
+  using DefaultValLayout = decltype(make_layout(shape_div(std::conditional_t<is_matrix_B, decltype(cute::reverse(BlockShape{})), BlockShape>{}, CopyThreadShape{})));
+
+  template<typename T>
+  using DefaultTiledCopy = decltype(make_tiled_copy(Copy_Atom<Traits_LD_t, T>{}, Layout<CopyThreadShape>{}, DefaultValLayout{}));
 
   // 2d copy parameters
   const void *base_ptr;
@@ -314,7 +321,6 @@ struct XE_2D_LD_Unpack {
   uint32_t height;
   uint32_t pitch;
   uint32_t stride_l = 0;
-
 
 
   XE_2D_LD_Unpack(const void *ptr, uint32_t y,

--- a/include/cute/atom/copy_traits_xe.hpp
+++ b/include/cute/atom/copy_traits_xe.hpp
@@ -293,7 +293,6 @@ template <class CopyOp, class StrideOrTensor = cute::Stride<int64_t, cute::Int<1
 struct XE_2D_LD_Unpack {
   using BlockShape = typename CopyOp::BlockShape; // this is not the same as Traits_LD_t::BlockShape iff is_matrix_B
   using Traits_LD_t = Copy_Traits<CopyOp, StrideOrTensor>;
- 
   static constexpr auto stride_rank = rank(StrideOrTensor{});
   static_assert(stride_rank == 2 || stride_rank == 3);
 

--- a/include/cutlass/gemm/collective/xe_array_mma.hpp
+++ b/include/cutlass/gemm/collective/xe_array_mma.hpp
@@ -98,17 +98,8 @@ struct CollectiveMma<MainloopIntelXeXMX16Group<Stages, Schedule>, TileShape_, El
   static constexpr auto Num_SGs = ATOM_N * ATOM_M * ATOM_K;
   static constexpr uint32_t MaxThreadsPerBlock = size(TiledMma{});
 
-  using CopyThreadShape = Shape<_1, Int<SubgroupSize>>;
-
-  using traits_load_A = Copy_Traits<GmemTiledCopyA, InternalStrideA>;
-  using atom_load_A = Copy_Atom<traits_load_A, ElementA>;
-  using val_layout_load_A = decltype(make_layout(shape_div(typename traits_load_A::BlockShape{}, CopyThreadShape{})));
-  using Copy_A = decltype(make_tiled_copy(atom_load_A{}, Layout<CopyThreadShape>{}, val_layout_load_A{}));
-
-  using traits_load_B = Copy_Traits<GmemTiledCopyB, InternalStrideB>;
-  using atom_load_B = Copy_Atom<traits_load_B, ElementB>;
-  using val_layout_load_B = decltype(make_layout(shape_div(typename traits_load_B::BlockShape{}, CopyThreadShape{})));
-  using Copy_B = decltype(make_tiled_copy(atom_load_B{}, Layout<CopyThreadShape>{}, val_layout_load_B{}));
+  using Copy_A = typename Copy_Traits<GmemTiledCopyA, InternalStrideA>::template DefaultTiledCopy<ElementA>;
+  using Copy_B = typename Copy_Traits<GmemTiledCopyB, InternalStrideB>::template DefaultTiledCopy<ElementB>;
 
   using TensorMKL = decltype(make_tensor(make_gmem_ptr(static_cast<ElementA const*>(nullptr)), make_shape(0,0,0), InternalStrideA{}));   //(m, k)
   using TensorNKL = decltype(make_tensor(make_gmem_ptr(static_cast<ElementB const*>(nullptr)), make_shape(0,0,0), InternalStrideB{}));   //(n, k)

--- a/include/cutlass/gemm/collective/xe_array_mma_fp8.hpp
+++ b/include/cutlass/gemm/collective/xe_array_mma_fp8.hpp
@@ -98,18 +98,9 @@ struct CollectiveMma<MainloopIntelXeXMX16GroupFP8<Stages, Schedule>, TileShape_,
 
   static constexpr auto Num_SGs = ATOM_N * ATOM_M * ATOM_K;
   static constexpr uint32_t MaxThreadsPerBlock = size(TiledMma{});
-
-  using CopyThreadShape = Shape<_1, Int<SubgroupSize>>;
-
-  using traits_load_A = Copy_Traits<GmemTiledCopyA, InternalStrideA>;
-  using atom_load_A = Copy_Atom<traits_load_A, ElementA>;
-  using val_layout_load_A = decltype(make_layout(shape_div(typename traits_load_A::BlockShape{}, CopyThreadShape{})));
-  using Copy_A = decltype(make_tiled_copy(atom_load_A{}, Layout<CopyThreadShape>{}, val_layout_load_A{}));
-
-  using traits_load_B = Copy_Traits<GmemTiledCopyB, InternalStrideB>;
-  using atom_load_B = Copy_Atom<traits_load_B, ElementB>;
-  using val_layout_load_B = decltype(make_layout(shape_div(typename traits_load_B::BlockShape{}, CopyThreadShape{})));
-  using Copy_B = decltype(make_tiled_copy(atom_load_B{}, Layout<CopyThreadShape>{}, val_layout_load_B{}));
+  
+  using Copy_A = typename Copy_Traits<GmemTiledCopyA, InternalStrideA>::template DefaultTiledCopy<ElementA>;
+  using Copy_B = typename Copy_Traits<GmemTiledCopyB, InternalStrideB>::template DefaultTiledCopy<ElementB>;
 
   using TensorMKL = decltype(make_tensor(make_gmem_ptr(static_cast<ElementA const*>(nullptr)), make_shape(0,0,0), InternalStrideA{}));   //(m, k)
   using TensorNKL = decltype(make_tensor(make_gmem_ptr(static_cast<ElementB const*>(nullptr)), make_shape(0,0,0), InternalStrideB{}));   //(n, k)

--- a/include/cutlass/gemm/collective/xe_mma.hpp
+++ b/include/cutlass/gemm/collective/xe_mma.hpp
@@ -100,17 +100,8 @@ struct CollectiveMma<MainloopIntelXeXMX16<Stages, Schedule>, TileShape_, Element
   static constexpr auto Num_SGs = ATOM_N * ATOM_M * ATOM_K;
   static constexpr uint32_t MaxThreadsPerBlock = size(TiledMma{});
 
-  using CopyThreadShape = Shape<_1, Int<SubgroupSize>>;
-
-  using traits_load_A = Copy_Traits<GmemTiledCopyA, StrideA>;
-  using atom_load_A = Copy_Atom<traits_load_A, ElementA>;
-  using val_layout_load_A = decltype(make_layout(shape_div(typename traits_load_A::BlockShape{}, CopyThreadShape{})));
-  using Copy_A = decltype(make_tiled_copy(atom_load_A{}, Layout<CopyThreadShape>{}, val_layout_load_A{}));
-
-  using traits_load_B = Copy_Traits<GmemTiledCopyB, StrideB>;
-  using atom_load_B = Copy_Atom<traits_load_B, ElementB>;
-  using val_layout_load_B = decltype(make_layout(shape_div(typename traits_load_B::BlockShape{}, CopyThreadShape{})));
-  using Copy_B = decltype(make_tiled_copy(atom_load_B{}, Layout<CopyThreadShape>{}, val_layout_load_B{}));
+  using Copy_A = typename Copy_Traits<GmemTiledCopyA, StrideA>::template DefaultTiledCopy<ElementA>;
+  using Copy_B = typename Copy_Traits<GmemTiledCopyB, StrideB>::template DefaultTiledCopy<ElementB>;
 
   // Host side kernel arguments
   struct Arguments {

--- a/include/cutlass/gemm/collective/xe_mma_fp8_scaling.hpp
+++ b/include/cutlass/gemm/collective/xe_mma_fp8_scaling.hpp
@@ -217,16 +217,9 @@ public:
 
   using CopyThreadShape = Shape<_1, Int<SubgroupSize>>;
   using CopyThreadShapeRev = decltype(cute::reverse(CopyThreadShape{}));
-
-  using traits_load_A = Copy_Traits<GmemTiledCopyA, StrideA>;
-  using atom_load_A = Copy_Atom<traits_load_A, ElementA>;
-  using val_layout_load_A = decltype(make_layout(shape_div(typename traits_load_A::BlockShape{}, CopyThreadShape{})));
-  using Copy_A = decltype(make_tiled_copy(atom_load_A{}, Layout<CopyThreadShape>{}, val_layout_load_A{}));
-
-  using traits_load_B = Copy_Traits<GmemTiledCopyB, StrideB>;
-  using atom_load_B = Copy_Atom<traits_load_B, ElementB>;
-  using val_layout_load_B = decltype(make_layout(shape_div(typename traits_load_B::BlockShape{}, CopyThreadShape{})));
-  using Copy_B = decltype(make_tiled_copy(atom_load_B{}, Layout<CopyThreadShape>{}, val_layout_load_B{}));
+  
+  using Copy_A = typename Copy_Traits<GmemTiledCopyA, StrideA>::template DefaultTiledCopy<ElementA>;
+  using Copy_B = typename Copy_Traits<GmemTiledCopyB, StrideB>::template DefaultTiledCopy<ElementB>;
 
   using traits_load_scaleA = Copy_Traits<GmemTiledCopyScaleA, NonVoidStrideScaleA>;
   using atom_load_scaleA = Copy_Atom<traits_load_scaleA, NonVoidElementScaleA>;

--- a/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp
+++ b/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp
@@ -233,16 +233,9 @@ public:
 
   using CopyThreadShape = Shape<_1, Int<SubgroupSize>>;
   using CopyThreadShapeRev = decltype(cute::reverse(CopyThreadShape{}));
-
-  using traits_load_A = Copy_Traits<GmemTiledCopyA, StrideA>;
-  using atom_load_A = Copy_Atom<traits_load_A, ElementA>;
-  using val_layout_load_A = decltype(make_layout(shape_div(typename traits_load_A::BlockShape{}, CopyThreadShape{})));
-  using Copy_A = decltype(make_tiled_copy(atom_load_A{}, Layout<CopyThreadShape>{}, val_layout_load_A{}));
-
-  using traits_load_B = Copy_Traits<GmemTiledCopyB, StrideB>;
-  using atom_load_B = Copy_Atom<traits_load_B, ElementB>;
-  using val_layout_load_B = decltype(make_layout(shape_div(typename traits_load_B::BlockShape{}, CopyThreadShape{})));
-  using Copy_B = decltype(make_tiled_copy(atom_load_B{}, Layout<CopyThreadShape>{}, val_layout_load_B{}));
+  
+  using Copy_A = typename Copy_Traits<GmemTiledCopyA, StrideA>::template DefaultTiledCopy<ElementA>;
+  using Copy_B = typename Copy_Traits<GmemTiledCopyB, StrideB>::template DefaultTiledCopy<ElementB>;
 
   using traits_load_scale = Copy_Traits<GmemTiledCopyScale, NonVoidStrideScale>;
   using atom_load_scale = Copy_Atom<traits_load_scale, NonVoidElementScale>;

--- a/tools/copy_debug/copy_debug.cpp
+++ b/tools/copy_debug/copy_debug.cpp
@@ -55,21 +55,17 @@ void copy_kernel(TensorS S) {
   }
   syncthreads();
 
-  using CopyThreadShape = Shape<_1, Int<SUBGROUP_SIZE>>;
-  using traits_load = Copy_Traits<CopyInstruction, decltype(S)>;
-  using Atom_load = Copy_Atom<traits_load, Element>;
-  auto tiled_copy_load = make_tiled_copy(Atom_load{}.with(S),
-    Layout<CopyThreadShape>{},
-    make_layout(shape_div(typename traits_load::BlockShape{}, CopyThreadShape{})));
+  using Copy = typename Copy_Traits<CopyInstruction, decltype(S)>::template DefaultTiledCopy<Element>;
+  Copy tiled_copy_load{Copy{}.with(S)};
     
   auto thr_copy_load = tiled_copy_load.get_slice(ThreadIdxX());
 
-  using actual_fragment_size = std::conditional_t<std::is_same_v<fragment_size, void>, C<Atom_load::NumValDst>, fragment_size>;
+  using actual_fragment_size = std::conditional_t<std::is_same_v<fragment_size, void>, C<Copy::NumValDst>, fragment_size>;
   Tensor fragment = make_tensor<Element>(make_shape(actual_fragment_size{},_1{},_1{}));
   clear(fragment);
 
-  static_assert(actual_fragment_size::value >= Atom_load::NumValDst, "fragment is too small to hold all results!");
-  Tensor fragment_copy_view = make_tensor(fragment.data(), make_shape(C<Atom_load::NumValDst>{},_1{},_1{}));
+  static_assert(actual_fragment_size::value >= Copy::NumValDst, "fragment is too small to hold all results!");
+  Tensor fragment_copy_view = make_tensor(fragment.data(), make_shape(C<Copy::NumValDst>{},_1{},_1{}));
   auto blk_load_S = cute::get_xe_tensor(S.shape());
   // preferably we would not partition to be generic in case layouts in copies are wrong, but now that copies check size we need to
   auto thread_s = thr_copy_load.partition_S(blk_load_S(_,_,0));


### PR DESCRIPTION
Create a helper for constructing tiled copies of default size. This should help us to avoid the bugs stemming from incorrect tiled copies.